### PR TITLE
Add Resultant rollup workflow + pilot test matrix trim (RLDEV-249)

### DIFF
--- a/.github/workflows/resultant-rollup.yml
+++ b/.github/workflows/resultant-rollup.yml
@@ -1,0 +1,142 @@
+name: Resultant rollup
+
+# Rolls up the existing Tests, Code Style, and Build workflows into a
+# single ``resultant/verification`` commit check that downstream
+# Resultant tooling (the Jira panel + workon CLI) can poll. The Resultant
+# side cares only about a single binary outcome per PR head SHA; this
+# workflow translates Pretix's already-green CI surface into that
+# contract without duplicating any actual test runs.
+#
+# Story 6.3 / RLDEV-249. See Epic 6 plan in
+# https://resultant.atlassian.net/browse/RLDEV-249 for background.
+#
+# How it fires:
+#
+#   * ``workflow_run`` only triggers when the dependency workflow exists
+#     on the default branch (master). So this file must be merged into
+#     master before the rollup is visible on pilot PRs.
+#   * Each completion of Tests / Code Style / Build fires this workflow
+#     once. The job below queries the latest run of all three workflows
+#     for the same head SHA and posts a single aggregated check.
+
+on:
+  workflow_run:
+    workflows:
+      - Tests
+      - Code Style
+      - Build
+    types:
+      - completed
+
+permissions:
+  checks: write
+  actions: read
+  contents: read
+
+jobs:
+  rollup:
+    name: Resultant verification rollup
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Aggregate triggering workflows and post resultant/verification check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const head_sha = context.payload.workflow_run.head_sha;
+            const event = context.payload.workflow_run.event;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            core.info(`Rollup triggered by ${context.payload.workflow_run.name} ` +
+              `(conclusion=${context.payload.workflow_run.conclusion}) ` +
+              `for head_sha=${head_sha} event=${event}`);
+
+            const trackedWorkflowNames = ["Tests", "Code Style", "Build"];
+
+            // Resolve workflow IDs once (workflows under .github/workflows/*.yml).
+            const allWorkflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
+              { owner, repo, per_page: 100 },
+            );
+
+            const workflowIdsByName = {};
+            for (const wf of allWorkflows) {
+              workflowIdsByName[wf.name] = wf.id;
+            }
+
+            const statuses = {};
+            let aggregate = "success";
+
+            for (const name of trackedWorkflowNames) {
+              const workflowId = workflowIdsByName[name];
+              if (!workflowId) {
+                statuses[name] = "missing";
+                aggregate = "failure";
+                continue;
+              }
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: workflowId,
+                head_sha,
+                per_page: 1,
+              });
+              const run = runs.data.workflow_runs[0];
+              if (!run) {
+                statuses[name] = "queued";
+                if (aggregate !== "failure") aggregate = "pending";
+                continue;
+              }
+              if (run.status !== "completed") {
+                statuses[name] = run.status;
+                if (aggregate !== "failure") aggregate = "pending";
+                continue;
+              }
+              // Completed.
+              statuses[name] = run.conclusion;
+              if (run.conclusion !== "success") {
+                aggregate = "failure";
+              }
+            }
+
+            const summaryLines = Object.entries(statuses).map(
+              ([name, value]) => `- **${name}**: \`${value}\``,
+            );
+            const summary = [
+              `Aggregate outcome: \`${aggregate}\` for commit \`${head_sha}\`.`,
+              "",
+              ...summaryLines,
+              "",
+              "_This check is posted by `.github/workflows/resultant-rollup.yml`._",
+              "_Resultant Jira/CLI surfaces poll the GitHub Checks API for the_",
+              "_`resultant/verification` context and surface the outcome on the_",
+              "_originating ticket._",
+            ].join("\n");
+
+            const conclusion = aggregate === "success"
+              ? "success"
+              : aggregate === "failure"
+                ? "failure"
+                : null; // pending
+
+            const status = conclusion ? "completed" : "in_progress";
+
+            const params = {
+              owner,
+              repo,
+              name: "resultant/verification",
+              head_sha,
+              status,
+              output: {
+                title: `Resultant verification (${aggregate})`,
+                summary,
+              },
+            };
+            if (conclusion) {
+              params.conclusion = conclusion;
+            }
+
+            core.info(`Posting check resultant/verification status=${status} ` +
+              `conclusion=${conclusion ?? "n/a"} for head_sha=${head_sha}`);
+
+            await github.rest.checks.create(params);

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,14 +22,22 @@ jobs:
     runs-on: ubuntu-22.04
     name: Tests
     strategy:
+      # TODO(RLDEV-249, pilot-only): restore the full matrix below after
+      # Advantix Pretix pilot. The pilot's tight feedback loop with Prem
+      # cannot afford the 4-combo runtime, so we narrow CI to the matrix
+      # cell that matches the deployed pilot env (Python 3.11 + Postgres
+      # 15). Restore:
+      #
+      #   python-version: ["3.10", "3.11", "3.13"]
+      #   database: [sqlite, postgres]
+      #   exclude:
+      #     - database: sqlite
+      #       python-version: "3.10"
+      #     - database: sqlite
+      #       python-version: "3.11"
       matrix:
-        python-version: ["3.10", "3.11", "3.13"]
-        database: [sqlite, postgres]
-        exclude:
-          - database: sqlite
-            python-version: "3.10"
-          - database: sqlite
-            python-version: "3.11"
+        python-version: ["3.11"]
+        database: [postgres]
     services:
       postgres:
         image: postgres:15


### PR DESCRIPTION
## Story — [RLDEV-249](https://resultant.atlassian.net/browse/RLDEV-249) Pilot P0 Epic 6 Story 6.3: CI rollup

Implements the Pretix-side of Resultant's pilot CI contract: a single `resultant/verification` commit check that downstream Resultant surfaces (the Jira panel + the `res workon` CLI) can poll for a binary pass/fail outcome per PR head SHA.

## Summary

- **New workflow** `.github/workflows/resultant-rollup.yml` — fires on `workflow_run` completion of `Tests` / `Code Style` / `Build`, queries all three for the head SHA via the GitHub Actions API, aggregates to success / failure / pending, and posts a single `resultant/verification` check via the GitHub Checks API.
- **Trim** `.github/workflows/tests.yml` matrix to **Python 3.11 + Postgres** (the deployed pilot env) for the duration of the pilot. Original 4-combo matrix preserved verbatim in a `TODO(RLDEV-249, pilot-only)` comment for one-revert restoration.

## What's new — `resultant-rollup.yml`

- **Trigger:** `workflow_run` of the three named workflows on completion (standard pattern that surfaces both the head SHA and a guaranteed firing per upstream completion).
- **Permissions:** `checks: write` (to post the rollup), `actions: read` (to list workflow runs), `contents: read`.
- **Implementation:** single `actions/github-script@v7` step. Walks the three named workflows, builds a markdown summary, and posts a check with `status="completed" + conclusion="success/failure"` or `status="in_progress"` if any tracked workflow is still running / queued / missing.

## Important constraint — must merge before it fires

`workflow_run` only triggers for workflows that exist on the **default branch** (`master`). This PR adds `resultant-rollup.yml` — until it lands on `master`, the workflow doesn't fire on any PR, including this one. The first PR that will actually exercise the rollup is the next PR opened against `master` after this one merges.

This is the standard chicken-and-egg with `workflow_run`-triggered workflows and is fine for the pilot.

## Test matrix trim (pilot-only)

The current matrix runs 4 combinations (Py 3.10 / 3.11 / 3.13 × sqlite / postgres with exclusions). For the Advantix pilot's tight feedback loop with Prem, the runtime cost isn't worth the breadth. Trim to Py 3.11 + Postgres only — matches the deployed env at advantix.tech. Restore is a single revert when the pilot ends; the original matrix is in a comment block immediately above the trimmed `matrix:` for trivial recovery.

## Test plan

- [x] YAML parse-clean (`python -c 'import yaml; yaml.safe_load(...)'`).
- [ ] **Cannot test end-to-end on this PR** (see "Important constraint" above — `workflow_run` needs the workflow on `master` to fire).
- [ ] **Verification PR after merge:** open a trivial no-op PR against `master`; expect to see (a) `Tests`, `Code Style`, `Build` run on the trimmed matrix; (b) `Resultant rollup` workflow fire as each of those completes; (c) a single `resultant/verification` check appear with conclusion `success` once all three complete.

## Pre-merge follow-ups (NOT in this PR)

- **Branch protection on `master`:** require `Tests`, `Code Style`, `Build`, and (once it has posted at least once) `resultant/verification`. Set this up via Settings → Branches → branch protection rule after this PR merges, so `resultant/verification` becomes a known context first.

## Risk classification

- **`.github/workflows/resultant-rollup.yml`** — additive (new workflow). Failure mode if buggy: posts a wrong check or no check; cannot affect Pretix test outcomes.
- **`.github/workflows/tests.yml`** — narrows the existing matrix only. Pre-pilot full matrix preserved in a `TODO(RLDEV-249, pilot-only)` comment for trivial restoration.

Closes [RLDEV-249](https://resultant.atlassian.net/browse/RLDEV-249). Part of Epic [RLDEV-246](https://resultant.atlassian.net/browse/RLDEV-246).