### PR TITLE
docs: fix README typo + verify resultant/verification rollup fires

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Reinventing ticket presales, one ticket at a time.
 Project status & release cycle
 ------------------------------
 
-While there is always a lot to do and improve on, pretix by now has been in use for thousands of events
+While there is always a lot to do and improve on, pretix by now has been in use for thousands of events and
 conferences that sold millions of tickets combined. We therefore think of pretix as being stable and ready to use.
 
 If you want to use or extend pretix, we strongly recommend to follow our `blog`_. We will announce all


### PR DESCRIPTION
## Why this PR exists

Two purposes (the PR is small enough that both fit):

1. **Real fix:** `README.rst` line 23 reads as a missing \"and\" — `\"thousands of events / conferences\"` should be `\"thousands of events and / conferences\"`.

2. **Verification of [#40](https://github.com/mantric/pretix/pull/40):** This is the first PR against master after the Resultant rollup workflow was merged. The rollup workflow only fires on workflows that exist on the default branch (the `workflow_run` constraint), so the very first opportunity to see it actually fire is the first PR to merge after #40. That's this one.

## What to expect on this PR's checks

- ✅ `Tests (3.11, postgres)` runs (matrix was trimmed in #40 to one combo)
- ✅ `Code Style / isort` + `Code Style / flake8` run
- ✅ `Code Style / licenseheaders` runs — **expected to fail** (pre-existing on master from earlier Advantix branding files, not introduced by this PR)
- ✅ `Build / Packaging (3.11)` runs — **expected to fail** (pre-existing `check-manifest` mismatch for `advantix-branding/*` files, also not introduced by this PR)
- ✅ `Resultant rollup` workflow fires after each of those completes, and posts a single `resultant/verification` commit check with conclusion = `failure` (because of the two pre-existing failures above)

The intent is **not** that this PR goes green — it's to confirm the rollup workflow actually fires + posts the check. We'll fix the two pre-existing failures separately before requiring `resultant/verification` in branch protection.

## After merge — branch protection setup

Once this PR lands and `resultant/verification` has appeared at least once in repo history, set up branch protection on `master`:

- Settings → Branches → Add rule for `master`
- Required status checks:
  - `Tests (3.11, postgres)`
  - `Code Style / isort`
  - `Code Style / flake8`
  - `resultant/verification`
- **Do not** include `licenseheaders` or `Packaging (3.11)` yet (they're broken for unrelated reasons; we'll add them once fixed in a follow-up).

## Risk

Single-line change in `README.rst`. Cannot break tests, packaging, or runtime. Worst case the rollup workflow itself has a bug and doesn't post the check — in which case the diagnostic is in the Actions tab and the README typo fix is still valuable on its own.

Closes the verification step on [RLDEV-249](https://resultant.atlassian.net/browse/RLDEV-249). Part of Epic [RLDEV-246](https://resultant.atlassian.net/browse/RLDEV-246).