### PR TITLE
chore: clear pre-existing CI debt (licenseheaders + check-manifest)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [check-manifest]
 ignore =
+    advantix-branding/**
     env/**
     doc/*
     deployment/*
@@ -33,6 +34,7 @@ ignore =
     src/tests/plugins/sendmail/*
     src/tests/plugins/ticketoutputpdf/*
     .*
+    .vscode/**
     CODE_OF_CONDUCT.md
     CONTRIBUTING.md
     Dockerfile

--- a/src/pretix/plugins/advantixtheme/__init__.py
+++ b/src/pretix/plugins/advantixtheme/__init__.py
@@ -1,1 +1,22 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
 """Internal storefront branding assets for the Advantix demo."""

--- a/src/pretix/plugins/advantixtheme/apps.py
+++ b/src/pretix/plugins/advantixtheme/apps.py
@@ -1,3 +1,24 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
 from django.apps import AppConfig
 
 

--- a/src/tests/presale/test_advantixtheme.py
+++ b/src/tests/presale/test_advantixtheme.py
@@ -1,3 +1,24 @@
+#
+# This file is part of pretix (Community Edition).
+#
+# Copyright (C) 2014-2020  Raphael Michel and contributors
+# Copyright (C) 2020-today pretix GmbH and contributors
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General
+# Public License as published by the Free Software Foundation in version 3 of the License.
+#
+# ADDITIONAL TERMS APPLY: Pursuant to Section 7 of the GNU Affero General Public License, additional terms are
+# applicable granting you additional permissions and placing additional restrictions on your usage of this software.
+# Please refer to the pretix LICENSE file to obtain the full terms applicable to this work. If you did not receive
+# this file, see <https://pretix.eu/about/en/license>.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along with this program.  If not, see
+# <https://www.gnu.org/licenses/>.
+#
 from datetime import timedelta
 
 import pytest


### PR DESCRIPTION
## Why

Two unrelated-to-Resultant CI gaps are blocking the `resultant/verification` rollup check (introduced in [#40](https://github.com/mantric/pretix/pull/40)) from ever going green. Both predate the rollup; both are minor; fixing them unblocks using `resultant/verification` as a required check in branch protection.

## Fixes

### 1. licenseheaders

Three Advantix theme files were missing the AGPL header the rest of the codebase carries:

- `src/pretix/plugins/advantixtheme/__init__.py`
- `src/pretix/plugins/advantixtheme/apps.py`
- `src/tests/presale/test_advantixtheme.py`

Re-running the project's standard:

```sh
cd src
licenseheaders -t ../.licenseheader -E .py -x "*/migrations/*.py"
```

produces exactly the headers added here. Verified idempotent — a second pass leaves the tree clean.

### 2. check-manifest

`check-manifest` was flagging two sets of files that are intentionally in version control but should not ship in the sdist:

- `advantix-branding/*` — source SVG artwork + the branding guide; committed PNG exports live under `src/pretix/plugins/advantixtheme/static/` (and those *are* in the sdist via the `recursive-include` rule).
- `.vscode/settings.json` — IDE config (the existing `.*` ignore line matches root-level dotfiles but not files inside dotdirs).

Two `ignore` entries added to `[check-manifest]` in `setup.cfg`. Verified locally:

```
$ check-manifest
lists of files in version control and sdist match
```

## Test plan

- [x] `licenseheaders` rerun produces no diff (idempotent).
- [x] `check-manifest` returns clean.
- [ ] CI confirms: `Code Style / licenseheaders` ✅, `Packaging (3.11)` ✅, and the rollup workflow re-fires posting `resultant/verification` with conclusion = `success` (all three tracked workflows green this time).
- [ ] After this PR + [#41](https://github.com/mantric/pretix/pull/41) both land on master, the next PR should see a green `resultant/verification` check.

## Pairs with

- [#41](https://github.com/mantric/pretix/pull/41) — the README typo PR that originally surfaced these failures via the rollup.

## Risk

Purely additive (license header comment blocks + two ignore lines). No code changes. Cannot affect tests, packaging, or runtime behavior.