### PR TITLE
Advantix PR -> deploy pipeline (Stories 6.5 + 6.7)

### DIFF
--- a/.github/workflows/advantix-image-build.yml
+++ b/.github/workflows/advantix-image-build.yml
@@ -1,0 +1,96 @@
+name: Advantix image build
+
+# Builds the Advantix pretix Docker image and pushes it to ECR under
+# two tags:
+#
+#   * `latest`            — the canonical "deploy this on master" tag
+#   * `<short-sha>`       — immutable per-commit tag used for rollback
+#
+# The Advantix EC2 webhook listener (deployment/aws-demo/webhook-listener.py)
+# pulls `latest` and restarts the pretix container when this workflow
+# finishes successfully on a master push. PR builds push to ECR too,
+# but only under the per-commit tag, so reviewers can pin/preview a
+# specific SHA without overwriting the live `latest`.
+#
+# Story 6.5 (RLDEV-251). See deployment/aws-demo/README.md and
+# deployment/aws-demo/PIPELINE.md for the end-to-end runbook.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  id-token: write     # required for AWS OIDC
+  contents: read
+
+concurrency:
+  # Coalesce in-flight builds for the same ref. Cancels superseded
+  # builds so we never race the webhook listener with stale images.
+  group: advantix-image-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: advantix-pretix-demo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF}" = "refs/heads/master" ]; then
+            echo "is_master=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_master=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        # IAM role with trust policy scoped to this repo + master/PR refs.
+        # See deployment/aws-demo/PIPELINE.md for the exact role bootstrap.
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ADVANTIX_ECR_PUSH_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          provenance: false
+          # Always push the per-commit tag. Push `latest` only on
+          # master so PR builds can't overwrite the live tag.
+          tags: |
+            ${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.short_sha }}
+            ${{ steps.tags.outputs.is_master == 'true' && format('{0}/{1}:latest', steps.ecr.outputs.registry, env.ECR_REPOSITORY) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          echo "## Pushed images" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ steps.tags.outputs.short_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.tags.outputs.is_master }}" = "true" ]; then
+            echo "- \`${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest\` (master only)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Advantix EC2 webhook listener will pull \`latest\` on the corresponding push event.**" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/deployment/aws-demo/PIPELINE.md
+++ b/deployment/aws-demo/PIPELINE.md
@@ -1,0 +1,283 @@
+# Advantix Pretix Pilot — PR → Deploy Pipeline
+
+This document is the operator runbook for Story 6.5 / Story 6.7 — the
+CI build + auto-deploy + rollback chain that makes a merged PR on
+`mantric/pretix master` land on `advantix.tech` within ~60-90 seconds.
+
+This is intentionally a **pilot-grade** pipeline. It runs a single
+docker container on a single EC2 instance against a single ECR
+`latest` tag. It is not a multi-region, multi-replica, blue-green
+production pipeline. The trade-offs are explained inline.
+
+---
+
+## End-to-end flow
+
+```
+   developer / Resultant
+            │
+            ▼
+   1. PR merges on mantric/pretix master
+            │
+            ▼
+   2. .github/workflows/advantix-image-build.yml
+      builds the docker image and pushes to ECR
+      under both `<short-sha>` (immutable) and
+      `latest` (mutable) tags.
+            │
+            ▼
+   3. EC2 instance (advantix-pretix-demo) runs the
+      systemd timer advantix-deploy-poller.timer
+      every 60 seconds. The timer fires the
+      poller shell script.
+            │
+            ▼
+   4. advantix-deploy-poller.sh:
+          aws ecr get-login-password | docker login …
+          docker compose pull pretix
+          if image digest moved → docker compose up -d pretix
+            │
+            ▼
+   5. Visit https://advantix.tech — change is live.
+            │
+            ▼
+   6. If broken: bash rollback-prod.sh <previous-short-sha>
+      re-tags an older image as `latest`. Within 60s
+      the poller rolls back.
+```
+
+Lower-latency alternative: `deployment/aws-demo/webhook-listener.py`
+is a drop-in replacement for the poller that fires within ~1 second of
+the master push instead of waiting for the timer. It's a strict
+superset; pick one. The cron poller is recommended for the pilot
+because it has zero public-facing HTTP surface on the EC2.
+
+---
+
+## One-time setup (do these in order)
+
+### A. ECR repository
+
+```sh
+aws ecr describe-repositories --region us-east-1 --repository-names advantix-pretix-demo \
+  || aws ecr create-repository --region us-east-1 --repository-name advantix-pretix-demo
+```
+
+(`deploy-demo-ec2.sh` already does this on first run, so if the demo
+EC2 is already up, you're done.)
+
+### B. GitHub Actions → ECR via OIDC
+
+1. **AWS — create the OIDC identity provider** (once per AWS account):
+
+   ```sh
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1
+   ```
+
+2. **AWS — create an IAM role with a trust policy scoped to this repo + master + PRs against master**:
+
+   Trust policy (replace `<acct-id>`):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [{
+       "Effect": "Allow",
+       "Principal": {
+         "Federated": "arn:aws:iam::<acct-id>:oidc-provider/token.actions.githubusercontent.com"
+       },
+       "Action": "sts:AssumeRoleWithWebIdentity",
+       "Condition": {
+         "StringEquals": {
+           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+         },
+         "StringLike": {
+           "token.actions.githubusercontent.com:sub": [
+             "repo:mantric/pretix:ref:refs/heads/master",
+             "repo:mantric/pretix:pull_request"
+           ]
+         }
+       }
+     }]
+   }
+   ```
+
+   Inline permissions policy (or a managed policy you attach):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "ecr:GetAuthorizationToken"
+         ],
+         "Resource": "*"
+       },
+       {
+         "Effect": "Allow",
+         "Action": [
+           "ecr:BatchCheckLayerAvailability",
+           "ecr:BatchGetImage",
+           "ecr:CompleteLayerUpload",
+           "ecr:DescribeImages",
+           "ecr:GetDownloadUrlForLayer",
+           "ecr:InitiateLayerUpload",
+           "ecr:PutImage",
+           "ecr:UploadLayerPart"
+         ],
+         "Resource": "arn:aws:ecr:us-east-1:<acct-id>:repository/advantix-pretix-demo"
+       }
+     ]
+   }
+   ```
+
+3. **GitHub — add the role ARN as a repository secret** named `ADVANTIX_ECR_PUSH_ROLE_ARN`.
+
+   ```sh
+   gh secret set ADVANTIX_ECR_PUSH_ROLE_ARN --repo mantric/pretix --body "arn:aws:iam::<acct-id>:role/<role-name>"
+   ```
+
+### C. EC2 — install the deploy poller
+
+SSM into the running Advantix EC2 instance (or SSH if you prefer):
+
+```sh
+aws ssm start-session --target <instance-id>
+```
+
+Then on the instance:
+
+```sh
+cd /opt/advantix-pretix-demo
+
+# If you haven't already pulled the pretix repo on the instance,
+# rsync these files there or download them from the merged commit.
+# E.g.:
+sudo curl -fsSLo install-deploy-poller.sh \
+  https://raw.githubusercontent.com/mantric/pretix/master/deployment/aws-demo/install-deploy-poller.sh
+sudo curl -fsSLo advantix-deploy-poller.sh \
+  https://raw.githubusercontent.com/mantric/pretix/master/deployment/aws-demo/advantix-deploy-poller.sh
+sudo curl -fsSLo advantix-deploy-poller.service \
+  https://raw.githubusercontent.com/mantric/pretix/master/deployment/aws-demo/advantix-deploy-poller.service
+sudo curl -fsSLo advantix-deploy-poller.timer \
+  https://raw.githubusercontent.com/mantric/pretix/master/deployment/aws-demo/advantix-deploy-poller.timer
+
+sudo bash install-deploy-poller.sh
+```
+
+That writes `/etc/advantix-deploy.env`, copies the poller script to
+`/opt/advantix-pretix-demo/`, installs the systemd unit + timer at
+`/etc/systemd/system/`, and enables + starts the timer.
+
+Verify:
+
+```sh
+sudo systemctl status advantix-deploy-poller.timer
+sudo journalctl -u advantix-deploy-poller.service --since "5 minutes ago"
+tail -f /var/log/advantix-deploy.log
+```
+
+### D. EC2 IAM permissions
+
+The EC2 instance profile (`advantix-pretix-demo-ec2-role` per
+`deploy-demo-ec2.sh`) already has `AmazonEC2ContainerRegistryReadOnly`
+attached, so the poller can `aws ecr get-login-password` without
+extra setup. No change needed.
+
+---
+
+## Operating the pipeline
+
+### Watch a deploy in flight
+
+```sh
+# From your laptop:
+gh run watch --repo mantric/pretix         # observe the GH Actions build
+# Then on the EC2 (via SSM):
+tail -f /var/log/advantix-deploy.log       # observe the pull/up
+```
+
+### Force an immediate deploy (skip waiting for the timer)
+
+```sh
+# On the EC2 (via SSM):
+sudo systemctl start advantix-deploy-poller.service
+```
+
+### Roll back to a previous image
+
+From your laptop (or anywhere with AWS credentials and docker):
+
+```sh
+bash deployment/aws-demo/rollback-prod.sh --list
+# pick a short-sha you trust, then:
+bash deployment/aws-demo/rollback-prod.sh <short-sha>
+
+# Or just "go back one":
+bash deployment/aws-demo/rollback-prod.sh
+```
+
+The script re-tags an older ECR image as `latest`. The poller picks
+it up within 60s and rolls the container. No EC2-side action needed.
+
+### Deploy a specific tag (not master HEAD)
+
+```sh
+bash deployment/aws-demo/rollback-prod.sh <short-sha>
+```
+
+— it's the same script. "Rollback" is just "deploy any tag I
+choose"; the asymmetric naming is intentional so the operator
+muscle memory matches the moment of urgency.
+
+---
+
+## Trade-offs and known sharp edges
+
+- **`latest` is mutable.** Two simultaneous master merges can race;
+  the second one wins. Acceptable for pilot (sequential review
+  cadence), unacceptable for a multi-team prod. Fix: switch to
+  digest-pinned task definitions (the appgraph ECS pattern).
+
+- **Poller logs every cycle to the systemd journal.** That's a lot of
+  noise. The shell script is quiet when there's no change (only logs
+  when the digest moves), but `systemctl status` will show every
+  invocation. Set `LogLevelMax=warning` in the unit if it's bothering
+  you.
+
+- **No automated rollback on bad health.** If a deploy breaks
+  `/health`, the poller still deploys it. The pilot relies on
+  reviewer attention + manual `rollback-prod.sh`. Add a health gate
+  in the poller if you need automatic protection.
+
+- **Webhook listener is unused by default.** It's checked in as an
+  alternative for when sub-second latency matters. If you switch to
+  it, the poller and the listener should NOT both be enabled — they
+  would compete for `docker compose up -d`.
+
+---
+
+## Verifying the chain end-to-end
+
+The canonical "did the pipeline work" smoke test:
+
+1. From your laptop, open a tiny visible-change PR. Example: bump
+   a copy string in `src/pretix/plugins/advantixtheme/`.
+2. Watch the build:
+   ```sh
+   gh run watch --repo mantric/pretix
+   ```
+3. Merge the PR.
+4. The merge triggers a `push` event on `master`. The image-build
+   workflow re-runs and now pushes BOTH `<sha>` and `latest`.
+5. Within 60s, the EC2 poller pulls `latest`. Tail
+   `/var/log/advantix-deploy.log` for the `deployed digest …` line.
+6. Refresh `https://advantix.tech/advantix/` — your change is live.
+
+If step 6 fails, `bash rollback-prod.sh` returns to the previous SHA
+in under a minute.

--- a/deployment/aws-demo/advantix-deploy-poller.service
+++ b/deployment/aws-demo/advantix-deploy-poller.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Advantix Pretix deploy poller (one-shot, invoked by .timer)
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-/etc/advantix-deploy.env
+User=root
+WorkingDirectory=/opt/advantix-pretix-demo
+ExecStart=/opt/advantix-pretix-demo/advantix-deploy-poller.sh
+
+# Don't restart on failure — the .timer will fire again in 60s and
+# retry naturally. Restart-loops would hide root causes.
+Restart=no

--- a/deployment/aws-demo/advantix-deploy-poller.sh
+++ b/deployment/aws-demo/advantix-deploy-poller.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Pull-based deploy poller for the Advantix EC2 demo.
+#
+# Story 6.5 (RLDEV-251) — the simpler half of the auto-deploy pair. A
+# systemd timer (see advantix-deploy-poller.timer) invokes this script
+# every minute. It runs `docker compose pull pretix` against ECR; if
+# `latest` has moved, `docker compose up -d pretix` rolls the running
+# container to the new image. Idempotent: if `latest` hasn't moved,
+# both commands are no-ops.
+#
+# We prefer this over a GitHub-webhook listener for the pilot because:
+#   * no public HTTPS endpoint on the EC2 to manage
+#   * no shared secret to rotate
+#   * deploy latency is at most one timer interval (~60s), which
+#     is well under what reviewers notice
+#   * total surface area is one shell script + one systemd timer
+#
+# If you need sub-second deploys, deployment/aws-demo/webhook-listener.py
+# is a drop-in alternative — it's a strict superset of this behavior.
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/advantix-pretix-demo}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ECR_REPOSITORY="${ECR_REPOSITORY:-advantix-pretix-demo}"
+LOG_FILE="${LOG_FILE:-/var/log/advantix-deploy.log}"
+
+# State file remembers the last successfully-deployed image digest so
+# we can announce "rolled X -> Y" cleanly in logs even though
+# `docker compose up -d` is itself idempotent.
+STATE_FILE="${STATE_FILE:-/var/lib/advantix-deploy-state}"
+
+log() {
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s %s\n' "$ts" "$*" | tee -a "$LOG_FILE"
+}
+
+if [[ ! -d "$APP_DIR" ]]; then
+  log "ERROR: APP_DIR ${APP_DIR} missing — has deploy-demo-ec2.sh been run?"
+  exit 1
+fi
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)"
+if [[ -z "$ACCOUNT_ID" ]]; then
+  log "ERROR: aws sts get-caller-identity failed — check the EC2 instance profile"
+  exit 1
+fi
+
+REGISTRY="${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+IMAGE_REF="${REGISTRY}/${ECR_REPOSITORY}:latest"
+
+PREVIOUS_DIGEST="$(cat "$STATE_FILE" 2>/dev/null || echo "")"
+
+# Authenticate against ECR. Short-lived token, so just re-login every cycle.
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$REGISTRY" >/dev/null
+
+cd "$APP_DIR"
+
+# `docker compose pull` is the no-op-when-no-change primitive.
+docker compose pull pretix >/dev/null
+
+CURRENT_DIGEST="$(docker image inspect "$IMAGE_REF" --format '{{index .RepoDigests 0}}' 2>/dev/null | awk -F'@' '{print $2}')"
+
+if [[ -z "$CURRENT_DIGEST" ]]; then
+  log "WARN: could not inspect ${IMAGE_REF} after pull; skipping this cycle"
+  exit 0
+fi
+
+if [[ "$CURRENT_DIGEST" == "$PREVIOUS_DIGEST" ]]; then
+  # No change. Don't even log every cycle — the timer fires every 60s
+  # and we don't want to drown the log.
+  exit 0
+fi
+
+log "image moved: ${PREVIOUS_DIGEST:-<none>} -> ${CURRENT_DIGEST}"
+log "running: docker compose up -d pretix"
+
+docker compose up -d pretix >>"$LOG_FILE" 2>&1
+
+# Persist the new digest only after a successful up. If up failed,
+# we retry on the next timer fire instead of declaring victory.
+mkdir -p "$(dirname "$STATE_FILE")"
+echo "$CURRENT_DIGEST" > "$STATE_FILE"
+log "deployed digest ${CURRENT_DIGEST}"

--- a/deployment/aws-demo/advantix-deploy-poller.timer
+++ b/deployment/aws-demo/advantix-deploy-poller.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Advantix Pretix deploy poller (fires every minute)
+
+[Timer]
+# Fire 60 seconds after boot, then every 60 seconds. AccuracySec
+# tightens the default fuzz so we don't drift by more than ~5s.
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=5
+
+# When the timer is enabled but the instance was off for a while,
+# fire immediately on boot to catch up. We don't want to wait a
+# full minute after a reboot before we're current.
+Persistent=true
+Unit=advantix-deploy-poller.service
+
+[Install]
+WantedBy=timers.target

--- a/deployment/aws-demo/install-deploy-poller.sh
+++ b/deployment/aws-demo/install-deploy-poller.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Installs the Advantix deploy poller onto the live EC2 instance.
+# Idempotent — re-running just refreshes the script and unit files.
+#
+# Run via SSM Session Manager or SSH:
+#
+#   sudo bash deployment/aws-demo/install-deploy-poller.sh
+#
+# Inputs (defaults shown):
+#   APP_DIR=/opt/advantix-pretix-demo
+#   AWS_REGION=us-east-1
+#   ECR_REPOSITORY=advantix-pretix-demo
+#
+# After install, watch the loop with:
+#
+#   sudo systemctl status advantix-deploy-poller.timer
+#   sudo journalctl -u advantix-deploy-poller.service -f
+#   tail -f /var/log/advantix-deploy.log
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "ERROR: must be run as root (try: sudo $0)" >&2
+  exit 1
+fi
+
+APP_DIR="${APP_DIR:-/opt/advantix-pretix-demo}"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ECR_REPOSITORY="${ECR_REPOSITORY:-advantix-pretix-demo}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "ERROR: APP_DIR ${APP_DIR} not found — run deploy-demo-ec2.sh first" >&2
+  exit 1
+fi
+
+echo "[install] writing /etc/advantix-deploy.env"
+cat > /etc/advantix-deploy.env <<EOF
+APP_DIR=${APP_DIR}
+AWS_REGION=${AWS_REGION}
+ECR_REPOSITORY=${ECR_REPOSITORY}
+LOG_FILE=/var/log/advantix-deploy.log
+STATE_FILE=/var/lib/advantix-deploy-state
+EOF
+chmod 0644 /etc/advantix-deploy.env
+
+echo "[install] copying poller script to ${APP_DIR}/advantix-deploy-poller.sh"
+install -m 0755 "${SCRIPT_DIR}/advantix-deploy-poller.sh" "${APP_DIR}/advantix-deploy-poller.sh"
+
+echo "[install] copying systemd unit files"
+install -m 0644 "${SCRIPT_DIR}/advantix-deploy-poller.service" /etc/systemd/system/advantix-deploy-poller.service
+install -m 0644 "${SCRIPT_DIR}/advantix-deploy-poller.timer" /etc/systemd/system/advantix-deploy-poller.timer
+
+systemctl daemon-reload
+
+echo "[install] enabling + starting timer"
+systemctl enable --now advantix-deploy-poller.timer
+
+echo
+echo "[install] done. Status:"
+systemctl status --no-pager advantix-deploy-poller.timer || true
+
+echo
+echo "Tail the deploy log with:"
+echo "  tail -f /var/log/advantix-deploy.log"
+echo "Force an immediate cycle with:"
+echo "  systemctl start advantix-deploy-poller.service"

--- a/deployment/aws-demo/rollback-prod.sh
+++ b/deployment/aws-demo/rollback-prod.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Rollback the Advantix prod container to a previous image revision.
+#
+# Story 6.7 (RLDEV-253) — the "I just merged something and the demo
+# is broken" lever. ECR keeps per-commit tags (`<short-sha>`), so we
+# re-tag a known-good SHA back to `latest` and let the existing
+# deploy-poller (or webhook) roll the container.
+#
+# Usage:
+#
+#   bash rollback-prod.sh                  # roll back to the previous tag
+#   bash rollback-prod.sh <short-sha>      # roll back to a specific SHA
+#   bash rollback-prod.sh --list           # list recent tags
+#
+# Requires: aws, jq, docker on the machine running the script.
+# Operates against ECR — does not need SSH/SSM into the EC2 itself,
+# because once ECR `latest` moves, the EC2's poller deploys it within
+# ~60s.
+
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ECR_REPOSITORY="${ECR_REPOSITORY:-advantix-pretix-demo}"
+LIMIT="${ROLLBACK_LIST_LIMIT:-20}"
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: missing required command: $1" >&2
+    exit 1
+  }
+}
+require_cmd aws
+require_cmd jq
+
+list_recent_tags() {
+  aws ecr describe-images --region "$AWS_REGION" \
+      --repository-name "$ECR_REPOSITORY" \
+      --query 'sort_by(imageDetails, &imagePushedAt)[*].{tags: imageTags, digest: imageDigest, pushed: imagePushedAt}' \
+      --output json \
+    | jq -r --argjson n "$LIMIT" 'reverse | .[0:$n] | .[] |
+        ((.tags // []) | map(select(. != "latest")) | join(",")) +
+        "\t" + (.pushed | tostring) +
+        "\t" + (.digest | tostring)'
+}
+
+if [[ "${1:-}" == "--list" || "${1:-}" == "-l" ]]; then
+  echo "Recent ${ECR_REPOSITORY} images (latest first):"
+  echo "TAG(S)                       PUSHED                          DIGEST"
+  list_recent_tags
+  exit 0
+fi
+
+# Find current `latest` digest so we know what we're rolling away from.
+CURRENT_DIGEST="$(aws ecr describe-images --region "$AWS_REGION" \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-ids imageTag=latest \
+  --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || echo "")"
+
+if [[ -z "$CURRENT_DIGEST" || "$CURRENT_DIGEST" == "None" ]]; then
+  echo "ERROR: no current 'latest' tag on ${ECR_REPOSITORY} — nothing to roll back" >&2
+  exit 1
+fi
+
+TARGET_SHA="${1:-}"
+
+if [[ -z "$TARGET_SHA" ]]; then
+  # Pick the most-recent non-latest tag that isn't the current latest digest.
+  TARGET_SHA="$(aws ecr describe-images --region "$AWS_REGION" \
+      --repository-name "$ECR_REPOSITORY" \
+      --query 'sort_by(imageDetails, &imagePushedAt)[*]' \
+      --output json \
+    | jq -r --arg cur "$CURRENT_DIGEST" 'reverse | .[]
+        | select(.imageDigest != $cur)
+        | (.imageTags // [])
+        | map(select(. != "latest" and (test("^[a-f0-9]{6,}$"))))
+        | .[0]' \
+    | grep -v '^null$' \
+    | head -n 1)"
+
+  if [[ -z "$TARGET_SHA" ]]; then
+    echo "ERROR: could not find a recent non-latest SHA tag to roll back to." >&2
+    echo "Try: $0 --list, then re-run with an explicit SHA." >&2
+    exit 1
+  fi
+  echo "[rollback] picking previous tag automatically: ${TARGET_SHA}"
+fi
+
+# Resolve the target tag to a digest so we can re-tag it.
+TARGET_DIGEST="$(aws ecr describe-images --region "$AWS_REGION" \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-ids imageTag="$TARGET_SHA" \
+  --query 'imageDetails[0].imageDigest' --output text 2>/dev/null || echo "")"
+
+if [[ -z "$TARGET_DIGEST" || "$TARGET_DIGEST" == "None" ]]; then
+  echo "ERROR: tag '${TARGET_SHA}' not found on ${ECR_REPOSITORY}" >&2
+  echo "Try: $0 --list" >&2
+  exit 1
+fi
+
+if [[ "$TARGET_DIGEST" == "$CURRENT_DIGEST" ]]; then
+  echo "[rollback] target ${TARGET_SHA} already IS 'latest' — nothing to do"
+  exit 0
+fi
+
+echo "[rollback] re-tagging ${TARGET_SHA} (${TARGET_DIGEST}) as 'latest'"
+echo "[rollback] previous 'latest' was ${CURRENT_DIGEST}"
+
+# Fetch the manifest by digest, then put it back under the `latest` tag.
+MANIFEST="$(aws ecr batch-get-image --region "$AWS_REGION" \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-ids imageDigest="$TARGET_DIGEST" \
+  --query 'images[0].imageManifest' --output text)"
+
+aws ecr put-image --region "$AWS_REGION" \
+  --repository-name "$ECR_REPOSITORY" \
+  --image-tag latest \
+  --image-manifest "$MANIFEST" >/dev/null
+
+echo "[rollback] done. The EC2 deploy poller will roll the container within ~60s."
+echo "[rollback] Watch with:  ssm-session -> tail -f /var/log/advantix-deploy.log"
+echo "[rollback] Or force immediate: ssm-session -> systemctl start advantix-deploy-poller.service"

--- a/deployment/aws-demo/webhook-listener.py
+++ b/deployment/aws-demo/webhook-listener.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""GitHub-webhook → docker compose pull/up deploy listener for Advantix EC2.
+
+Story 6.5 (RLDEV-251) — the EC2 side of the Resultant pilot auto-deploy
+loop. Receives a push-event webhook from GitHub when mantric/pretix
+master moves, validates the HMAC signature, then refreshes the running
+pretix container from ECR's `latest` tag.
+
+Why not a self-hosted GHA runner? Because runners execute arbitrary
+workflow code with the runner's IAM/identity; putting one inside the
+prod EC2 widens the blast radius. A scope-bound webhook listener
+(this script) can only do the one thing it's coded to do.
+
+Runtime:
+- Python 3.11 stdlib only (no Flask). Reduces attack surface and
+  install footprint on the EC2.
+- Listens on 127.0.0.1:8765. The host nginx layer (see
+  router-webhook.conf) terminates HTTPS on /resultant-webhook/ and
+  proxies here.
+- Validates `X-Hub-Signature-256` against the shared secret loaded
+  from /etc/advantix-webhook.env at boot.
+- Only acts on `push` events for `refs/heads/master`. Pings get a 200.
+  PR events are ignored (image build is enough; deploy waits for the
+  merge).
+- Synchronously runs `docker compose pull pretix && docker compose
+  up -d pretix` in the configured APP_DIR.
+
+Operational expectations:
+- Stay tiny. If you're tempted to add features, add them as separate
+  endpoints with their own auth, don't grow this one.
+- Logs to stdout (systemd captures it). Don't write secrets to logs.
+- Exit non-zero on unrecoverable errors so systemd restarts cleanly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import subprocess
+import sys
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Optional
+
+LOG = logging.getLogger("advantix-webhook")
+
+# Config — read once at startup. Treat as immutable per-process.
+LISTEN_HOST = os.environ.get("WEBHOOK_LISTEN_HOST", "127.0.0.1")
+LISTEN_PORT = int(os.environ.get("WEBHOOK_LISTEN_PORT", "8765"))
+WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "").encode("utf-8")
+APP_DIR = Path(os.environ.get("APP_DIR", "/opt/advantix-pretix-demo"))
+TARGET_REF = os.environ.get("WEBHOOK_TARGET_REF", "refs/heads/master")
+ECR_REGISTRY = os.environ.get("ECR_REGISTRY", "")  # e.g. <acct>.dkr.ecr.<region>.amazonaws.com
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+
+def _verify_signature(secret: bytes, body: bytes, header_value: Optional[str]) -> bool:
+    """Constant-time HMAC-SHA256 verification of the X-Hub-Signature-256 header."""
+    if not header_value or not header_value.startswith("sha256="):
+        return False
+    expected = hmac.new(secret, body, hashlib.sha256).hexdigest()
+    provided = header_value[len("sha256=") :]
+    return hmac.compare_digest(expected, provided)
+
+
+def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    """Subprocess wrapper that logs the command + outcome without leaking env."""
+    LOG.info("$ %s", " ".join(args))
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        **kwargs,
+    )
+    if result.stdout:
+        LOG.info("stdout:\n%s", result.stdout.rstrip())
+    if result.stderr:
+        LOG.info("stderr:\n%s", result.stderr.rstrip())
+    if result.returncode != 0:
+        LOG.error("command exited %s", result.returncode)
+    return result
+
+
+def deploy_latest() -> bool:
+    """Refresh the running pretix container from ECR's `latest` tag.
+
+    Returns True on success, False on any non-zero step. Caller is
+    responsible for surfacing the result to the webhook response.
+    """
+    if not APP_DIR.exists():
+        LOG.error("APP_DIR %s does not exist", APP_DIR)
+        return False
+
+    if ECR_REGISTRY:
+        login = _run(
+            [
+                "bash",
+                "-lc",
+                f"aws ecr get-login-password --region {AWS_REGION} "
+                f"| docker login --username AWS --password-stdin {ECR_REGISTRY}",
+            ]
+        )
+        if login.returncode != 0:
+            return False
+
+    pull = _run(["docker", "compose", "pull", "pretix"], cwd=str(APP_DIR))
+    if pull.returncode != 0:
+        return False
+
+    up = _run(["docker", "compose", "up", "-d", "pretix"], cwd=str(APP_DIR))
+    if up.returncode != 0:
+        return False
+
+    return True
+
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    server_version = "advantix-webhook/1.0"
+
+    def log_message(self, fmt: str, *args) -> None:  # noqa: D401
+        LOG.info("%s - %s", self.client_address[0], fmt % args)
+
+    def _reply(self, status: HTTPStatus, body: dict) -> None:
+        payload = json.dumps(body).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        if self.path != "/resultant-webhook":
+            self._reply(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+            return
+
+        content_length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(content_length) if content_length else b""
+
+        if not _verify_signature(WEBHOOK_SECRET, body, self.headers.get("X-Hub-Signature-256")):
+            LOG.warning("signature verification FAILED for delivery %s",
+                        self.headers.get("X-GitHub-Delivery"))
+            self._reply(HTTPStatus.FORBIDDEN, {"error": "signature invalid"})
+            return
+
+        event = self.headers.get("X-GitHub-Event") or ""
+        delivery = self.headers.get("X-GitHub-Delivery") or ""
+
+        if event == "ping":
+            self._reply(HTTPStatus.OK, {"pong": True, "delivery": delivery})
+            return
+
+        if event != "push":
+            self._reply(HTTPStatus.OK, {"ignored": True, "event": event})
+            return
+
+        try:
+            payload = json.loads(body.decode("utf-8")) if body else {}
+        except json.JSONDecodeError:
+            self._reply(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON"})
+            return
+
+        ref = payload.get("ref")
+        if ref != TARGET_REF:
+            LOG.info("ignoring push for ref %s (target %s)", ref, TARGET_REF)
+            self._reply(HTTPStatus.OK, {"ignored": True, "ref": ref})
+            return
+
+        head_sha = (payload.get("after") or "")[:12]
+        LOG.info("deploying head_sha=%s (delivery=%s)", head_sha, delivery)
+
+        ok = deploy_latest()
+        if ok:
+            self._reply(HTTPStatus.OK, {"deployed": True, "ref": ref, "head_sha": head_sha})
+        else:
+            self._reply(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"deployed": False, "ref": ref, "head_sha": head_sha,
+                 "hint": "see systemd journalctl -u advantix-webhook -f"},
+            )
+
+    def do_GET(self) -> None:  # noqa: N802
+        # Liveness probe — no auth, no side effects. Useful for nginx
+        # upstream health checks and human curl sanity checks.
+        if self.path == "/healthz":
+            self._reply(HTTPStatus.OK, {"status": "healthy"})
+            return
+        self._reply(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not WEBHOOK_SECRET:
+        LOG.error("GITHUB_WEBHOOK_SECRET is empty; refusing to start")
+        return 1
+
+    LOG.info("listening on %s:%s, target_ref=%s, app_dir=%s",
+             LISTEN_HOST, LISTEN_PORT, TARGET_REF, APP_DIR)
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), WebhookHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        LOG.info("shutdown requested")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Stories

- [RLDEV-251 (Story 6.5)](https://resultant.atlassian.net/browse/RLDEV-251) — Auto-deploy via EC2 webhook on master push (cron-poller variant primary; webhook listener checked in as alternative)
- [RLDEV-253 (Story 6.7)](https://resultant.atlassian.net/browse/RLDEV-253) — Rollback / pin-tag-to-prod script

This closes the loop between "PR merges on mantric/pretix master" and "change is live on advantix.tech".

## What lands

| Path | Purpose |
|---|---|
| [`.github/workflows/advantix-image-build.yml`](.github/workflows/advantix-image-build.yml) | Builds + pushes pretix Docker image to ECR on every push/PR. Master pushes also overwrite `latest`. Uses GitHub OIDC against an AWS IAM role (no long-lived keys). |
| [`deployment/aws-demo/advantix-deploy-poller.sh`](deployment/aws-demo/advantix-deploy-poller.sh) | One-shot deploy: `aws ecr get-login-password` → `docker compose pull` → `docker compose up -d pretix` if digest moved. Idempotent. |
| [`deployment/aws-demo/advantix-deploy-poller.service`](deployment/aws-demo/advantix-deploy-poller.service) + [`.timer`](deployment/aws-demo/advantix-deploy-poller.timer) | systemd timer fires the poller every 60s. |
| [`deployment/aws-demo/install-deploy-poller.sh`](deployment/aws-demo/install-deploy-poller.sh) | One-shot installer — run on the EC2 once via SSM Session Manager. |
| [`deployment/aws-demo/webhook-listener.py`](deployment/aws-demo/webhook-listener.py) | Alternative sub-second-latency listener. HMAC-SHA256 validated. NOT installed by default. |
| [`deployment/aws-demo/rollback-prod.sh`](deployment/aws-demo/rollback-prod.sh) | Re-tags any earlier `<short-sha>` ECR image as `latest`. Within 60s the poller rolls back. `--list` enumerates recent tags; no-arg picks previous. |
| [`deployment/aws-demo/PIPELINE.md`](deployment/aws-demo/PIPELINE.md) | End-to-end operator runbook: setup, operations, trade-offs, smoke test. |

## Manual operator steps (documented inline in PIPELINE.md)

1. **AWS OIDC + IAM role for ECR push** — IAM identity provider + role with trust policy scoped to `repo:mantric/pretix:ref:refs/heads/master` and `repo:mantric/pretix:pull_request`.
2. **GitHub secret** `ADVANTIX_ECR_PUSH_ROLE_ARN` — the role's ARN from step 1.
3. **SSM into the Advantix EC2 instance** and run `sudo bash install-deploy-poller.sh`.

After those three, push a test commit → CI builds + pushes → poller deploys → site reflects within ~60s.

## What's deliberately deferred

- **Preview slot** ([RLDEV-250 / Story 6.4](https://resultant.atlassian.net/browse/RLDEV-250)) — preview.advantix.tech subdomain + second pretix container. Scoping the pilot demo to "auto-deploy to advantix.tech on merge" demonstrates the loop with one fewer moving part. Preview slot is a clean follow-up PR.
- **Failure UX** ([RLDEV-254 / Story 6.8](https://resultant.atlassian.net/browse/RLDEV-254)) — lives in appgraph, separate PR.

## Trade-offs (also called out in PIPELINE.md)

- **`latest` is mutable.** Two simultaneous master merges race; second wins. Acceptable for pilot's sequential review cadence.
- **No automatic rollback on bad `/health`.** Pilot relies on reviewer attention + manual `rollback-prod.sh`. Adding a health gate is one if-statement in the poller — trivial to add when needed.
- **Poller adds ~60s deploy latency.** Sub-second alternative (`webhook-listener.py`) is checked in but not wired by default.

## Test plan

- [x] YAML parse-clean
- [x] All shell scripts pass `bash -n`
- [x] Python webhook listener `py_compile`s
- [ ] **End-to-end smoke (post-merge):** operator completes the 3 manual setup steps, then opens a tiny visible-change PR. After merge, `tail -f /var/log/advantix-deploy.log` shows `deployed digest …` within 60s; `https://advantix.tech/advantix/` reflects the change. Rollback verified by `bash rollback-prod.sh --list` → pick previous → `bash rollback-prod.sh <sha>` → site reverts within 60s.

Part of Epic [RLDEV-246](https://resultant.atlassian.net/browse/RLDEV-246).