### PR TITLE
chore: pilot-deploy smoke marker (Story 6.9 golden-path verification)

### DIFF
--- a/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
+++ b/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
@@ -1,3 +1,28 @@
+/*
+ * Pilot deploy smoke marker — Story 6.9 (RLDEV-255) golden-path verification.
+ *
+ * The .advantix-pilot-deploy-marker-2026-05-26 selector below is purely
+ * a token for end-to-end pipeline verification. Curl the served CSS:
+ *
+ *   curl -s https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css \
+ *     | grep advantix-pilot-deploy-marker-2026-05-26
+ *
+ * If the marker is present, then: PR merged on master -> GH Actions built
+ * the image -> ECR `latest` moved -> EC2 deploy poller pulled within ~60s
+ * -> Docker container restarted -> CloudFront (eventually) serves the new
+ * static asset. CloudFront's TTL for /static is long, so the curl above
+ * may need a cache-busting query param OR a direct origin check via
+ *
+ *   curl -sH "Host: advantix.tech" http://<ec2-public-ip>/static/pretixplugins/advantixtheme/advantix.css \
+ *     | grep advantix-pilot-deploy-marker-2026-05-26
+ *
+ * Remove this marker once the pilot pipeline is validated.
+ */
+.advantix-pilot-deploy-marker-2026-05-26 {
+    /* Intentional no-op rule; never selected. Marker only. */
+    display: none;
+}
+
 body.advantix-theme {
     --advantix-midnight: #0A0E1A;
     --advantix-surface: #141828;


### PR DESCRIPTION
## Story — [RLDEV-255](https://resultant.atlassian.net/browse/RLDEV-255) Pilot P0 Epic 6 Story 6.9: golden-path verification

Final closing step on Epic 6 — drives a real PR through the now-live auto-deploy pipeline and confirms the chain end-to-end.

## What this PR does

Adds a no-op CSS selector `.advantix-pilot-deploy-marker-2026-05-26` to the Advantix theme stylesheet. The selector is invisible to storefront users (it's `display: none` on a class no element ever has) but becomes discoverable via curl on the served asset:

```sh
curl -s https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css \
  | grep advantix-pilot-deploy-marker-2026-05-26
```

If that grep finds the marker, the pipeline ran end-to-end:

1. PR merge on master ✅ (this PR landing)
2. `.github/workflows/advantix-image-build.yml` builds the docker image ✅ (the CI checks below)
3. Push to ECR under `<short-sha>` and `latest` tags ✅ (verifiable in run log)
4. EC2 `advantix-deploy-poller.timer` fires within 60s ✅ (verifiable in `/var/log/advantix-deploy.log`)
5. `docker compose pull` notices new digest → `docker compose up -d pretix` ✅ (verifiable in same log)
6. New pretix container serves the updated `/static/` asset

CloudFront's `/static/*` TTL is 365d (set in the pretix-internal nginx), so the public curl above may be cache-hit for a while after deploy. **Faster verification path** — bypass CloudFront and hit the origin directly:

```sh
# From any host that can reach the EC2 elastic IP:
curl -sH "Host: advantix.tech" http://<ec2-public-ip>/static/pretixplugins/advantixtheme/advantix.css \
  | grep advantix-pilot-deploy-marker-2026-05-26
```

The marker is intended to be removed once the pipeline is validated — it's a smoke token, not a feature.

## Test plan

- [x] CSS file lints/parses (it's a comment + a `display: none` rule — minimal)
- [ ] CI confirms `licenseheaders`, `Packaging`, `Tests (3.11, postgres)`, `Code Style/isort`, `Code Style/flake8` all pass on this PR
- [ ] `resultant/verification` rollup posts `success`
- [ ] The new `Advantix image build` workflow (from #43) runs and pushes per-SHA tag to ECR (but does NOT push `latest` — that's master-only)
- [ ] After merge: master push triggers re-build; ECR `latest` digest changes
- [ ] After merge: EC2 poller log shows `image moved: <old-digest> -> <new-digest>` followed by `deployed digest <new>`
- [ ] After ~CloudFront-cache-window (or via direct origin probe): marker appears in served CSS

## Risk

A single-line CSS rule that never matches any selector. Cannot affect runtime behavior, layout, performance, or accessibility. Safe to revert at any time.

Part of Epic [RLDEV-246](https://resultant.atlassian.net/browse/RLDEV-246).