### PR TITLE
ci(advantix): invalidate CloudFront after master deploys

### DIFF
--- a/.github/workflows/advantix-image-build.yml
+++ b/.github/workflows/advantix-image-build.yml
@@ -85,6 +85,50 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Wait for EC2 poller to roll the container
+        # The EC2 systemd timer (advantix-deploy-poller.timer) fires
+        # every 60s. Sleeping here lets the poller pull the new
+        # `latest` image and restart the pretix container BEFORE we
+        # invalidate CloudFront — otherwise the next CF origin-pull
+        # would cache the OLD content and we'd need a second
+        # invalidation to fix it.
+        if: steps.tags.outputs.is_master == 'true'
+        run: sleep 90
+
+      - name: Invalidate CloudFront cache
+        # CloudFront caches /static/* aggressively (365d TTL on the
+        # behavior fronting advantix.tech). After a deploy, end users
+        # would otherwise see stale CSS/JS for up to a year. This step
+        # busts the edge cache so the new image's static assets are
+        # served on the next request.
+        #
+        # Requires:
+        #   * repo variable ADVANTIX_CF_DISTRIBUTION_ID set to the
+        #     CloudFront distribution id (E... or d...) that fronts
+        #     advantix.tech.
+        #   * the OIDC role (ADVANTIX_ECR_PUSH_ROLE_ARN) granted
+        #     cloudfront:CreateInvalidation on that distribution ARN.
+        #
+        # The step is a no-op (with a workflow warning) if the variable
+        # is unset — that lets the pipeline keep working during the
+        # bootstrap window before the variable + IAM grant are in place.
+        if: steps.tags.outputs.is_master == 'true'
+        env:
+          DISTRIBUTION_ID: ${{ vars.ADVANTIX_CF_DISTRIBUTION_ID }}
+        run: |
+          if [ -z "${DISTRIBUTION_ID}" ]; then
+            echo "::warning::ADVANTIX_CF_DISTRIBUTION_ID repo variable is not set — skipping CloudFront invalidation. Set it via: gh variable set ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix --body <id>"
+            exit 0
+          fi
+          INVALIDATION_ID="$(aws cloudfront create-invalidation \
+            --distribution-id "${DISTRIBUTION_ID}" \
+            --paths '/*' \
+            --query 'Invalidation.Id' \
+            --output text)"
+          echo "[cloudfront] created invalidation ${INVALIDATION_ID} on ${DISTRIBUTION_ID} for paths '/*'"
+          echo "INVALIDATION_ID=${INVALIDATION_ID}" >> "$GITHUB_OUTPUT"
+        id: invalidate
+
       - name: Summary
         run: |
           echo "## Pushed images" >> "$GITHUB_STEP_SUMMARY"
@@ -92,5 +136,9 @@ jobs:
           if [ "${{ steps.tags.outputs.is_master }}" = "true" ]; then
             echo "- \`${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:latest\` (master only)" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Advantix EC2 webhook listener will pull \`latest\` on the corresponding push event.**" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Advantix EC2 deploy poller will pull \`latest\` on the next 60s cycle.**" >> "$GITHUB_STEP_SUMMARY"
+            if [ -n "${{ steps.invalidate.outputs.INVALIDATION_ID }}" ]; then
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "**CloudFront invalidation:** \`${{ steps.invalidate.outputs.INVALIDATION_ID }}\` for paths \`/*\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi

--- a/deployment/aws-demo/PIPELINE.md
+++ b/deployment/aws-demo/PIPELINE.md
@@ -131,15 +131,45 @@ EC2 is already up, you're done.)
            "ecr:UploadLayerPart"
          ],
          "Resource": "arn:aws:ecr:us-east-1:<acct-id>:repository/advantix-pretix-demo"
+       },
+       {
+         "Effect": "Allow",
+         "Action": [
+           "cloudfront:CreateInvalidation"
+         ],
+         "Resource": "arn:aws:cloudfront::<acct-id>:distribution/<distribution-id>"
        }
      ]
    }
    ```
 
+   The `cloudfront:CreateInvalidation` permission is required so the
+   workflow can bust the edge cache after a deploy. See the
+   `Invalidate CloudFront cache` step in `advantix-image-build.yml`
+   and "CloudFront cache busting" below.
+
 3. **GitHub — add the role ARN as a repository secret** named `ADVANTIX_ECR_PUSH_ROLE_ARN`.
 
    ```sh
    gh secret set ADVANTIX_ECR_PUSH_ROLE_ARN --repo mantric/pretix --body "arn:aws:iam::<acct-id>:role/<role-name>"
+   ```
+
+4. **GitHub — add the CloudFront distribution id as a repository variable** named `ADVANTIX_CF_DISTRIBUTION_ID`.
+
+   The workflow's invalidation step is a no-op (with a warning) until
+   this variable is set, so the order of operations doesn't matter:
+   you can set the variable before or after deploying the workflow.
+
+   ```sh
+   gh variable set ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix --body "<distribution-id>"
+   ```
+
+   Find the distribution id with:
+
+   ```sh
+   aws cloudfront list-distributions \
+     --query 'DistributionList.Items[?Aliases.Items && contains(Aliases.Items, `advantix.tech`)].Id' \
+     --output text
    ```
 
 ### C. EC2 — install the deploy poller
@@ -235,6 +265,49 @@ bash deployment/aws-demo/rollback-prod.sh <short-sha>
 choose"; the asymmetric naming is intentional so the operator
 muscle memory matches the moment of urgency.
 
+### Manually invalidate CloudFront (if needed)
+
+The workflow automatically invalidates `/*` after every master
+deploy. If you need to bust the cache out-of-band (e.g., the
+workflow's invalidation step failed, or you changed CloudFront
+config directly), run:
+
+```sh
+DIST_ID="$(gh variable get ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix)"
+aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths '/*'
+```
+
+This is rare — the typical deploy path doesn't need it.
+
+---
+
+## CloudFront cache busting (Story 6.x follow-up)
+
+CloudFront's `/static/*` behavior fronts `advantix.tech` with a
+**365-day TTL**, so a fresh deploy's CSS/JS/images are invisible
+to end users at the CDN edge until that TTL expires.
+
+The workflow now handles this automatically by:
+
+1. Pushing the image to ECR with the `latest` tag.
+2. **Sleeping 90 seconds** to let the EC2 poller pick up `latest`
+   and `docker compose up -d` the new container. Without this
+   sleep, CloudFront's next origin-pull would re-cache the OLD
+   content and we'd need a second invalidation to fix it.
+3. Issuing one CloudFront invalidation against path `/*`. One path
+   per invalidation; well under the 1,000-paths-per-month free
+   tier. Invalidation typically propagates across the edge in
+   ~30-60s.
+
+Total wall-clock from merge to fresh content at the edge: ~5 min
+(2-3 min build + 90s wait + 60s CF propagate).
+
+If `ADVANTIX_CF_DISTRIBUTION_ID` is unset, the invalidation step
+posts a workflow warning and exits 0 — the rest of the deploy
+chain still runs. This is intentional so the workflow doesn't
+hard-fail during a bootstrap window where the IAM grant or repo
+variable is still being applied.
+
 ---
 
 ## Trade-offs and known sharp edges
@@ -277,7 +350,18 @@ The canonical "did the pipeline work" smoke test:
    workflow re-runs and now pushes BOTH `<sha>` and `latest`.
 5. Within 60s, the EC2 poller pulls `latest`. Tail
    `/var/log/advantix-deploy.log` for the `deployed digest …` line.
-6. Refresh `https://advantix.tech/advantix/` — your change is live.
+6. The workflow then sleeps 90s and issues a CloudFront invalidation
+   for path `/*`. Watch for the `[cloudfront] created invalidation ...`
+   line in the workflow logs.
+7. Within ~60s of step 6, CloudFront finishes propagating. Refresh
+   `https://advantix.tech/advantix/` — your change is live at the
+   edge. If you want to bypass CF entirely (e.g., to verify the
+   origin before edge propagation completes), probe the EC2 IP
+   directly:
 
-If step 6 fails, `bash rollback-prod.sh` returns to the previous SHA
-in under a minute.
+   ```sh
+   curl -H "Host: advantix.tech" http://<ec2-eip>/static/pretixplugins/advantixtheme/advantix.css
+   ```
+
+If step 7 fails, `bash rollback-prod.sh` returns to the previous SHA
+in under a minute (and the next master push will re-invalidate CF).


### PR DESCRIPTION
## Summary

Closes the last gap in the Advantix pilot deploy pipeline: CloudFront's `/static/*` 365-day TTL meant fresh CSS/JS/images stayed invisible at the edge for up to a year after a deploy. This PR makes the workflow self-bust the cache.

- New step `Wait for EC2 poller to roll the container` — sleeps 90s so the EC2 systemd-timer poller has time to `docker compose pull` and `up -d` the new image **before** we invalidate. Without this ordering, CloudFront's next origin-pull would re-cache the OLD content.
- New step `Invalidate CloudFront cache` — single `aws cloudfront create-invalidation --paths '/*'`. One path per call, well under the 1,000/month free tier. Master-only (PR builds don't move `latest` so they don't need to invalidate).
- Reads the distribution id from a repo variable `ADVANTIX_CF_DISTRIBUTION_ID`. If the variable is unset, the step posts a workflow warning and exits 0 — pipeline keeps working through the bootstrap window.
- PIPELINE.md updated: new step 4 under "One-time setup" for the repo variable, inline-policy snippet for the IAM grant, a "Manually invalidate CloudFront" runbook, and an updated end-to-end verification flow that now includes the CF propagation step.

Total wall-clock from merge to fresh content at the edge: ~5 min (2-3 min build + 90s wait + ~60s CF propagate). Previously: up to 365 days, or a manual invalidation.

## Bootstrap required after merge (one-time)

1. Find the distribution id:
   ```sh
   aws cloudfront list-distributions \
     --query 'DistributionList.Items[?Aliases.Items && contains(Aliases.Items, `advantix.tech`)].Id' \
     --output text
   ```
2. Set the repo variable:
   ```sh
   gh variable set ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix --body "<distribution-id>"
   ```
3. Add to the inline policy of the `GitHubActionsAdvantixEcrPush` IAM role:
   ```json
   {
     "Effect": "Allow",
     "Action": ["cloudfront:CreateInvalidation"],
     "Resource": "arn:aws:cloudfront::928112000430:distribution/<distribution-id>"
   }
   ```

## Test plan

- [ ] Required checks pass on this PR (Tests, Packaging, isort, flake8, licenseheaders, resultant/verification).
- [ ] After merge + bootstrap, open a tiny visible-change PR. Confirm the workflow logs show `[cloudfront] created invalidation <id> on <dist-id> for paths '/*'`.
- [ ] Within ~60s of that line, `https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css` reflects the change (no `?v=` cache-bust query needed).
- [ ] Origin probe `curl -H "Host: advantix.tech" http://44.203.226.36/static/...` still works as a CF-bypass smoke check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)