### PR TITLE
chore(advantix): swap CloudFront for Caddy TLS on the EC2

### DIFF
--- a/deployment/aws-demo/Caddyfile
+++ b/deployment/aws-demo/Caddyfile
@@ -1,0 +1,59 @@
+# Advantix demo TLS terminator + reverse proxy.
+#
+# This replaces the previous CloudFront-fronted architecture
+# (CF + ACM + viewer function) with a single-server stack:
+#
+#   client --> [Caddy on EC2: 80/443] --> [pretix container: 80]
+#
+# Why we did this for the Advantix demo pilot:
+#   * CloudFront's /static/* TTL (365d) + opaque CF->origin
+#     connectivity issues meant fresh deploys weren't visible at the
+#     edge without a per-deploy invalidation, and even that depends
+#     on CF->origin actually reaching the EC2.
+#   * For a single-server, single-customer demo, none of CF's
+#     features (edge cache, DDoS shield, geo distribution) pay for
+#     their operational complexity.
+#
+# Caddy handles ACME (Let's Encrypt) automatically using the http-01
+# challenge on port 80. The issued cert + key + ACME state live in
+# the `caddy_data` named volume in docker-compose.yml. DO NOT delete
+# that volume or you'll re-issue from scratch and may trip ACME rate
+# limits (5 certs per exact-domain-set per week).
+#
+# Two redirect rules that used to live in
+# `advantix-root-redirect.js` (a CloudFront viewer-request function)
+# now live here instead:
+#   * www.advantix.tech     -> https://advantix.tech (301 permanent)
+#   * GET advantix.tech /   -> /advantix/            (302 found)
+
+# www -> apex (preserves URI + query).
+www.advantix.tech {
+    redir https://advantix.tech{uri} permanent
+}
+
+# Apex hosts the pretix UI.
+advantix.tech {
+    encode gzip zstd
+
+    # Root path bounce so visitors landing on advantix.tech are
+    # taken straight to the Advantix organizer slug. Matches the
+    # behavior the CloudFront function used to provide.
+    @root path /
+    redir @root /advantix/ 302
+
+    # Everything else proxies into the pretix container.
+    # `pretix:80` is resolved via the docker compose network — the
+    # pretix container exposes 80 internally (see docker-compose.yml)
+    # but no longer binds host port 80, because Caddy owns 80+443
+    # on the host.
+    #
+    # X-Forwarded-Proto=https tells pretix's Django app (with
+    # trust_x_forwarded_proto=true in pretix.cfg) that the original
+    # request was HTTPS, so it emits https:// URLs in redirects /
+    # absolute links rather than http://.
+    reverse_proxy pretix:80 {
+        header_up Host {host}
+        header_up X-Forwarded-Proto https
+        header_up X-Forwarded-For {remote}
+    }
+}

--- a/deployment/aws-demo/PIPELINE.md
+++ b/deployment/aws-demo/PIPELINE.md
@@ -265,29 +265,35 @@ bash deployment/aws-demo/rollback-prod.sh <short-sha>
 choose"; the asymmetric naming is intentional so the operator
 muscle memory matches the moment of urgency.
 
-### Manually invalidate CloudFront (if needed)
+### Manually invalidate CloudFront (legacy — pre-Caddy era)
 
-The workflow automatically invalidates `/*` after every master
-deploy. If you need to bust the cache out-of-band (e.g., the
-workflow's invalidation step failed, or you changed CloudFront
-config directly), run:
+> The Advantix demo no longer runs behind CloudFront; Caddy serves
+> directly from the EC2. This runbook is kept for historical context
+> in case CF is reintroduced. See `README.md` "Cutover from
+> CloudFront" for the migration that retired this step.
 
 ```sh
 DIST_ID="$(gh variable get ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix)"
 aws cloudfront create-invalidation --distribution-id "$DIST_ID" --paths '/*'
 ```
 
-This is rare — the typical deploy path doesn't need it.
-
 ---
 
-## CloudFront cache busting (Story 6.x follow-up)
+## CloudFront cache busting (dormant — pre-Caddy era)
 
-CloudFront's `/static/*` behavior fronts `advantix.tech` with a
-**365-day TTL**, so a fresh deploy's CSS/JS/images are invisible
-to end users at the CDN edge until that TTL expires.
+> **Status: dormant.** The Advantix demo no longer runs behind
+> CloudFront — TLS is now terminated by Caddy on the EC2 directly
+> (see `README.md`). The workflow's `Invalidate CloudFront cache`
+> step is preserved for now as a graceful no-op (it skips when
+> `ADVANTIX_CF_DISTRIBUTION_ID` is unset) and will be removed in a
+> follow-up PR once the Caddy cutover has soaked for a week. To
+> silence the workflow warning immediately, delete the variable:
+> `gh variable delete ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix`.
 
-The workflow now handles this automatically by:
+The historical rationale: CloudFront's `/static/*` behavior fronted
+`advantix.tech` with a **365-day TTL**, so a fresh deploy's
+CSS/JS/images were invisible to end users at the CDN edge until
+that TTL expired. The workflow handled this by:
 
 1. Pushing the image to ECR with the `latest` tag.
 2. **Sleeping 90 seconds** to let the EC2 poller pick up `latest`
@@ -299,14 +305,14 @@ The workflow now handles this automatically by:
    tier. Invalidation typically propagates across the edge in
    ~30-60s.
 
-Total wall-clock from merge to fresh content at the edge: ~5 min
-(2-3 min build + 90s wait + 60s CF propagate).
+Total wall-clock from merge to fresh content at the edge was ~5
+min (2-3 min build + 90s wait + 60s CF propagate). Under Caddy
+the equivalent is ~3 min (build + EC2 poller pick-up + container
+restart); the 90s wait + invalidation steps are now no-ops.
 
 If `ADVANTIX_CF_DISTRIBUTION_ID` is unset, the invalidation step
 posts a workflow warning and exits 0 — the rest of the deploy
-chain still runs. This is intentional so the workflow doesn't
-hard-fail during a bootstrap window where the IAM grant or repo
-variable is still being applied.
+chain still runs.
 
 ---
 
@@ -350,18 +356,23 @@ The canonical "did the pipeline work" smoke test:
    workflow re-runs and now pushes BOTH `<sha>` and `latest`.
 5. Within 60s, the EC2 poller pulls `latest`. Tail
    `/var/log/advantix-deploy.log` for the `deployed digest …` line.
-6. The workflow then sleeps 90s and issues a CloudFront invalidation
-   for path `/*`. Watch for the `[cloudfront] created invalidation ...`
-   line in the workflow logs.
-7. Within ~60s of step 6, CloudFront finishes propagating. Refresh
-   `https://advantix.tech/advantix/` — your change is live at the
-   edge. If you want to bypass CF entirely (e.g., to verify the
-   origin before edge propagation completes), probe the EC2 IP
-   directly:
+6. (Dormant) The workflow then sleeps 90s and tries the CloudFront
+   invalidation step. Since CF is decommissioned, this step posts
+   a warning and exits 0. No action needed.
+7. Refresh `https://advantix.tech/advantix/` — your change is
+   live. Caddy serves directly from the freshly-rolled pretix
+   container; there's no edge cache to expire. If something
+   looks wrong, bypass Caddy and probe the pretix container on
+   the EC2 host directly:
 
    ```sh
-   curl -H "Host: advantix.tech" http://<ec2-eip>/static/pretixplugins/advantixtheme/advantix.css
+   # On the EC2 (admin profile via SSM):
+   docker compose exec pretix \
+     curl -sI -H "Host: advantix.tech" -H "X-Forwarded-Proto: https" \
+     http://127.0.0.1/advantix/
    ```
 
 If step 7 fails, `bash rollback-prod.sh` returns to the previous SHA
-in under a minute (and the next master push will re-invalidate CF).
+in under a minute. The poller picks up the rolled-back image within
+60s and Caddy keeps serving HTTPS through the swap (no cert
+re-issuance needed).

--- a/deployment/aws-demo/README.md
+++ b/deployment/aws-demo/README.md
@@ -1,38 +1,49 @@
 # AWS Demo / Dev Staging
 
-This deployment package now supports the maintained low-budget shape for the Advantix demo:
+This deployment package supports the maintained low-budget shape for
+the Advantix demo:
 
-- 1 `EC2` instance running Docker Compose
-- 1 pretix container using the repo's built-in `pretix all` entrypoint
-- 1 local `PostgreSQL` container
-- 1 local `Redis` container
-- 1 Elastic IP for stable origin access
-- 1 `CloudFront` distribution for public HTTPS
-- 1 `ACM` certificate in `us-east-1`
-- external DNS hosted at Spaceship, not Route 53
+- 1 EC2 instance running Docker Compose
+- 1 Caddy container terminating TLS on host ports 80 + 443 (Let's
+  Encrypt via ACME http-01, automatic)
+- 1 pretix container reverse-proxied from Caddy on the docker network
+- 1 local PostgreSQL container
+- 1 local Redis container
+- 1 Elastic IP for stable inbound access
+- External DNS hosted at Spaceship (apex + www A records → EIP)
 
-This is intentionally a demo / dev staging target, not a production HA stack.
+This is intentionally a demo / dev staging target, not a production
+HA stack.
+
+> **Note.** Earlier revisions of this README described a CloudFront +
+> ACM front-end. That layer was removed for the Advantix pilot
+> because the demo doesn't benefit from edge caching or DDoS
+> shielding and the CF→origin path added operational surface that
+> wasn't pulling its weight. The pre-CF code path (legacy CF function
+> `advantix-root-redirect.js`, deploy-script CF blocks) is preserved
+> in the repo as historical context but is no longer the deploy
+> target. See "Cutover from CloudFront" below for the migration
+> runbook.
 
 ## Final Architecture
 
 - Viewer traffic: `advantix.tech` and `www.advantix.tech`
-- DNS host: Spaceship
-- TLS termination: CloudFront with ACM
-- Origin: single `EC2` instance over plain HTTP on port `80`
+- DNS host: Spaceship (apex A and www A both point to the EC2 EIP)
+- TLS termination: Caddy on the EC2 (Let's Encrypt, automatic
+  renewal)
+- Reverse proxy: Caddy → `pretix:80` over the docker compose
+  network
 - App data: local Docker volumes and `/opt/advantix-pretix-demo/data`
+- Cert state: `caddy-data` named volume (durable — see Caddyfile
+  notes)
 - Jobs: host cron runs `pretix cron` every 5 minutes
 - Admin/backend: `/control/`
 - Organizer storefront: `/advantix/`
 
-This keeps cost down by avoiding:
+Cost avoidance: ALB, ECS, RDS, ElastiCache, EFS, CloudFront.
 
-- `ALB`
-- `ECS`
-- `RDS`
-- `ElastiCache`
-- `EFS`
-
-Tradeoff: the stack is single-instance. If the EC2 instance fails, the site is down until the instance is restored or replaced.
+Tradeoff: single-instance. If the EC2 fails the site is down until
+it's restored or replaced.
 
 ## Record Live Inventory
 
@@ -41,32 +52,36 @@ After you deploy, record these values in your operator notes:
 - AWS account ID
 - EC2 region
 - EC2 instance ID
-- EC2 public IP
+- EC2 public IP (the Elastic IP)
 - EC2 public DNS
-- CloudFront distribution ID
-- CloudFront domain
-- ACM certificate ARN
-- CloudFront function name
 
 ## What You Get
 
-- Public HTTPS demo site on `advantix.tech`
-- `www` redirected to apex
-- root `/` redirected to `/advantix/`
-- seeded polished global demo storefront for `Advantix`
-- demo event pages under `/advantix/<event-slug>/`
+- Public HTTPS demo site on `https://advantix.tech`
+- `www` redirected to apex (Caddyfile rule)
+- root `/` redirected to `/advantix/` (Caddyfile rule)
+- seeded polished Advantix storefront with branding, hero copy, and
+  demo events
 - pretix backend at `/control/`
-- seeded Advantix storefront branding with logo, favicon, hero copy, and social preview assets
-- image-based redeploys by rerunning the EC2 deploy script and restarting the instance services
+- image-based redeploys via the master-push deploy pipeline (see
+  `PIPELINE.md`)
 
 ## Files
 
-- `docker-compose.yml`: on-instance service definition
-- `nginx.conf`: origin proxy config used by the demo stack
+- `docker-compose.yml`: on-instance service definition (Caddy + db
+  + redis + pretix)
+- `Caddyfile`: Caddy reverse-proxy + TLS config (apex + www, ACME)
+- `nginx.conf`: in-pretix-container nginx config (serves the
+  django unix socket; reached by Caddy on `pretix:80`)
 - `pretix.cfg.template`: rendered instance config
-- `deploy-demo-ec2.sh`: one-shot EC2 bootstrap and app deploy
-- `advantix-root-redirect.js`: CloudFront viewer-request function source
-- `src/pretix/plugins/advantixtheme/`: storefront-only Advantix theme assets and CSS
+- `deploy-demo-ec2.sh`: one-shot EC2 bootstrap (legacy: still
+  provisions CloudFront — see "Legacy CloudFront tooling" below)
+- `advantix-deploy-poller.{sh,service,timer}`: master-push deploy
+  poller (see `PIPELINE.md`)
+- `advantix-root-redirect.js`: **legacy** CloudFront function
+  source, retained for historical context only — its behavior now
+  lives in `Caddyfile`
+- `rollback-prod.sh`: re-tag an older ECR image as `latest`
 
 ## Phase 1: Base EC2 Deploy
 
@@ -77,55 +92,59 @@ chmod +x deployment/aws-demo/deploy-demo-ec2.sh
 deployment/aws-demo/deploy-demo-ec2.sh
 ```
 
-Optional overrides:
+The deploy script provisions the EC2, security group, EIP, and
+initial container set. **The script still contains CloudFront
+provisioning blocks** (legacy) — for a fresh Caddy-only stack, skip
+those blocks or comment them out before running. The Advantix demo
+EC2 already exists, so this script is no longer run for the
+pilot's day-to-day deploys.
 
-```bash
-AWS_REGION=us-west-2 \
-APP_NAME=advantix-pretix-demo \
-INSTANCE_TYPE=t3.small \
-deployment/aws-demo/deploy-demo-ec2.sh
-```
+First boot runs the full pretix migration set, so the site can
+return 502 briefly before becoming healthy.
 
-The deploy script:
+## Phase 2: DNS at Spaceship
 
-- builds and pushes the image to ECR
-- creates or reuses the IAM role, profile, security group, EC2 instance, and EIP
-- uploads `docker-compose.yml`, `nginx.conf`, `.env`, and `pretix.cfg`
-- uploads the committed Advantix raster branding assets into `/data/branding/`
-- starts `db`, `redis`, and `pretix`
-- seeds the Advantix organizer, branded storefront settings, demo events, and admin user
-
-First boot runs the full pretix migration set, so the site can return `502` briefly before becoming healthy.
-
-## Phase 2: CloudFront + ACM + Spaceship DNS
-
-Keep Spaceship nameservers in place. Do not move DNS to Route 53 if you want to preserve Spaceship email forwarding.
-
-### ACM validation records
-
-Leave the ACM validation `CNAME` records in Spaceship so ACM can renew the certificate.
-Pull them from ACM after the certificate request is created:
-
-```bash
-aws acm describe-certificate \
-  --region us-east-1 \
-  --certificate-arn <acm-certificate-arn>
-```
+Keep Spaceship nameservers in place. Do not move DNS to Route 53
+if you want to preserve Spaceship email forwarding.
 
 ### Website DNS records
 
-Spaceship flattens a root-level `CNAME`, so use `CNAME` for both records:
+Point apex and www directly at the EC2 EIP:
 
 ```dns
-@    CNAME  <cloudfront-domain>
-www  CNAME  <cloudfront-domain>
+@    A      <ec2-eip>
+www  A      <ec2-eip>
 ```
 
-Do not remove your existing MX, SPF, DKIM, or email-forwarding records.
+Both records have a low TTL during cutover (e.g. 60 seconds)
+so propagation is fast. Once the cutover is verified, raise to
+~3600s.
+
+Do not remove your existing MX, SPF, DKIM, or email-forwarding
+records.
+
+### TLS / ACME
+
+Caddy obtains and renews the certificate automatically via the
+http-01 challenge as long as:
+
+- port 80 is open from the public internet to the EC2 EIP
+  (security group allows `0.0.0.0/0` on tcp/80)
+- the apex and www A records resolve to the EC2 EIP
+
+The first issuance happens within ~30 seconds of Caddy starting
+once DNS is correct. Watch `docker compose logs -f caddy` for
+"certificate obtained successfully" lines.
+
+The issued cert + ACME state lives in the `caddy-data` named
+volume. Treat that volume as durable; deleting it triggers
+re-issuance and can hit Let's Encrypt's rate limit of 5 certs
+per exact-domain-set per week.
 
 ## Runtime Configuration
 
-For the CloudFront-fronted domain, the live pretix origin config should be:
+For the Caddy-fronted domain, the live pretix origin config should
+be:
 
 ```ini
 [pretix]
@@ -133,117 +152,196 @@ url=https://advantix.tech
 trust_x_forwarded_proto=true
 ```
 
-CloudFront should:
+Caddy sends `X-Forwarded-Proto: https` to the pretix container,
+which the Django app uses to emit `https://` URLs in redirects and
+absolute links.
 
-- use aliases `advantix.tech` and `www.advantix.tech`
-- use your ACM certificate in `us-east-1`
-- redirect viewers from HTTP to HTTPS
-- send `X-Forwarded-Proto: https` to the origin
-- point to your EC2 public DNS name on HTTP port `80`
+## Cutover from CloudFront
 
-## Branding Maintenance
+The Advantix pilot ran briefly on CloudFront → EC2 before being
+simplified to direct DNS → Caddy → pretix. If you're doing the
+cutover now, the sequence is:
 
-The demo branding is intentionally reproducible:
+1. **Lower DNS TTL ahead of time.** A few hours before cutover, set
+   the apex + www records' TTL at Spaceship to 60 seconds. This
+   shortens the propagation window during the actual switch.
 
-- source SVG artwork lives in `advantix-branding/`
-- committed production PNG exports live in `src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/assets/`
-- the storefront-only CSS layer lives in `src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css`
-- the deploy script copies those PNGs to `/data/branding/` and seeds pretix file settings from there
+2. **Pull the new compose files onto the EC2.** SSM into the
+   instance with the admin profile (devbox's `staging-ops` lacks
+   `ssm:StartSession` on this instance):
 
-If you update the Advantix look, regenerate the committed PNG exports first, then rerun `deployment/aws-demo/deploy-demo-ec2.sh` so the EC2 host receives the new assets and the seed step reapplies them.
+   ```bash
+   aws --profile principledevolution-ai ssm start-session \
+     --target i-0e527b07a48513bb7
 
-## CloudFront Function Behavior
+   cd /opt/advantix-pretix-demo
+   for f in docker-compose.yml Caddyfile nginx.conf; do
+     sudo curl -fsSL \
+       "https://raw.githubusercontent.com/mantric/pretix/master/deployment/aws-demo/${f}" \
+       -o "${f}"
+   done
+   ```
 
-The active viewer-request function source is stored in:
+3. **Verify the security group allows tcp/80 + tcp/443 from
+   `0.0.0.0/0`.** Required for Caddy's ACME http-01 challenge and
+   for the public site itself.
 
-- `deployment/aws-demo/advantix-root-redirect.js`
+4. **Switch DNS at Spaceship.** Update both records:
 
-Its behavior is:
+   ```dns
+   @    A      <ec2-eip>
+   www  A      <ec2-eip>
+   ```
 
-- `www.advantix.tech/*` -> `https://advantix.tech/*`
-- `https://advantix.tech/` -> `/advantix/`
-- all other requests pass through unchanged
+   (Both replace the prior CloudFront CNAMEs.) Verify propagation
+   from multiple resolvers:
 
-### Update the function
+   ```bash
+   dig +short advantix.tech @1.1.1.1
+   dig +short advantix.tech @8.8.8.8
+   dig +short advantix.tech @9.9.9.9
+   ```
 
-```bash
-aws cloudfront describe-function \
-  --name advantix-root-redirect \
-  --stage DEVELOPMENT
+5. **Roll the compose stack on the EC2.** Once DNS shows the EIP
+   from a public resolver:
 
-aws cloudfront update-function \
-  --name advantix-root-redirect \
-  --if-match <etag-from-describe-function> \
-  --function-code fileb://deployment/aws-demo/advantix-root-redirect.js \
-  --function-config Comment="Redirect root and www for Advantix",Runtime=cloudfront-js-2.0
+   ```bash
+   cd /opt/advantix-pretix-demo
+   docker compose pull caddy
+   docker compose up -d --remove-orphans
+   docker compose logs -f caddy
+   ```
 
-aws cloudfront publish-function \
-  --name advantix-root-redirect \
-  --if-match <etag-from-update-function>
-```
+   Look for `certificate obtained successfully` for both
+   `advantix.tech` and `www.advantix.tech`. This typically lands
+   inside the first 30-60 seconds.
 
-The distribution already associates this function on `viewer-request`, so publishing a new function version is enough unless you replace the function name.
+6. **Smoke-test from a local terminal:**
+
+   ```bash
+   curl -sI https://advantix.tech/                 # expect 302 -> /advantix/
+   curl -sI https://advantix.tech/advantix/        # expect 200
+   curl -sI https://www.advantix.tech/             # expect 301 -> https://advantix.tech/
+   curl -sI https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css
+   ```
+
+7. **Disable CloudFront.** Once the Caddy stack is verified, set
+   the CloudFront distribution `Enabled=false` (admin profile).
+   Leave it disabled for a day or two as a fast rollback before
+   deleting. The CF function `advantix-root-redirect` can be
+   left in place until full delete — it's only invoked while the
+   distribution is enabled.
+
+8. **Unset the CF invalidation variable.** The pipeline's
+   `Invalidate CloudFront cache` step is a graceful no-op when
+   the variable is unset, so:
+
+   ```bash
+   gh variable delete ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix
+   ```
+
+   The step will warn-and-exit on subsequent master pushes
+   without doing anything destructive. A follow-up PR will rip
+   the step out entirely.
+
+**Cutover downtime:** ~5-15 minutes total, dominated by DNS
+propagation + first ACME issuance.
+
+**Rollback:** if any step above fails badly, revert DNS to the
+CloudFront CNAMEs (still recorded in Spaceship change history)
+and re-enable the CF distribution. Pretix itself is unchanged,
+so reverting fronting reverts the user-facing site to the prior
+behavior.
 
 ## App Update Workflow
 
-For app changes:
+The day-to-day deploy is automated by the master-push pipeline:
 
-1. Push a new image with `deployment/aws-demo/deploy-demo-ec2.sh`.
-2. Upload any changed `docker-compose.yml`, `nginx.conf`, or `pretix.cfg`.
-3. Restart the app container on the instance.
-4. Verify the CloudFront path and the direct origin health.
+1. A PR merges to `mantric/pretix` master.
+2. GitHub Actions builds + pushes the image to ECR.
+3. The EC2's `advantix-deploy-poller.timer` (every 60s) detects the
+   new `latest` digest and runs `docker compose up -d pretix`.
+4. Caddy keeps running; only pretix is rolled.
 
-Useful origin-side commands through SSM:
+See `PIPELINE.md` for the full operator runbook.
+
+Manual `pretix` restart on the EC2:
 
 ```bash
 cd /opt/advantix-pretix-demo
-docker compose ps
-docker compose logs --tail=200 pretix
 docker compose restart pretix
-curl -I -H "Host: advantix.tech" -H "X-Forwarded-Proto: https" http://127.0.0.1/advantix/
-curl -I -H "Host: advantix.tech" -H "X-Forwarded-Proto: https" http://127.0.0.1/advantix/hollywood-premiere-night/
+docker compose logs --tail=200 pretix
 ```
 
-Useful CloudFront verification from a local terminal before DNS cutover:
+Useful debug probes from the EC2 host (bypass Caddy):
 
 ```bash
-curl -I --connect-to advantix.tech:443:<cloudfront-domain>:443 https://advantix.tech/
-curl -I --connect-to advantix.tech:443:<cloudfront-domain>:443 https://advantix.tech/advantix/
-curl -I --connect-to advantix.tech:443:<cloudfront-domain>:443 https://advantix.tech/advantix/hollywood-premiere-night/
-curl -I --connect-to www.advantix.tech:443:<cloudfront-domain>:443 "https://www.advantix.tech/advantix/?x=1"
+# Reach the pretix container directly via its docker network IP
+docker compose exec pretix curl -sI -H "Host: advantix.tech" -H "X-Forwarded-Proto: https" http://127.0.0.1/advantix/
+
+# Probe the origin from outside (bypass Caddy + bypass cert checks)
+curl -k -H "Host: advantix.tech" http://<ec2-eip>:80/advantix/   # NOTE: 80 only reaches Caddy; 80 → 443 redirect
 ```
 
-Expected results:
+Caddy redirects all plain HTTP to HTTPS, so the public site has no
+HTTP-served pages.
 
-- root returns `302` to `/advantix/`
-- organizer page returns `200`
-- event page returns `200`
-- `www` returns `301` to apex and preserves path/query
+## Legacy CloudFront tooling
+
+These files are retained for historical context and rollback only.
+They are not part of the current deploy target.
+
+- `advantix-root-redirect.js`: the CloudFront viewer-request
+  function source. Its behavior now lives in `Caddyfile`.
+- The CloudFront-provisioning blocks inside `deploy-demo-ec2.sh`.
+- The `Invalidate CloudFront cache` step in
+  `.github/workflows/advantix-image-build.yml`. The step is
+  graceful no-op when `ADVANTIX_CF_DISTRIBUTION_ID` is unset; a
+  follow-up PR will remove it once the cutover is verified for a
+  week.
 
 ## Operational Notes
 
-- ACM renewal is automatic as long as the validation CNAMEs remain in Spaceship DNS.
-- The public EC2 IP is an origin detail. Users should access the site through CloudFront, not directly.
-- `KnownDomain` entries are not used for `advantix.tech` in this setup. The apex host is treated as the system domain and CloudFront handles the root redirect.
-- This stack is fine for demos, testing, investor/customer previews, and internal staging. It is not a production multi-tenant ticketing platform.
+- TLS renewal is automatic via Caddy's ACME loop. Watch
+  `docker compose logs caddy` periodically.
+- The public EC2 IP is the website endpoint now. Hide it via a
+  WAF or a fronted CDN if needed; we don't for the pilot.
+- This stack is fine for demos, testing, investor/customer
+  previews, and internal staging. It is not a production
+  multi-tenant ticketing platform.
 
 ## Troubleshooting
 
 - `advantix.tech` does not resolve:
-  The Spaceship apex and `www` records are not pointed at CloudFront yet.
-- HTTPS works on CloudFront but pretix emits `http://` redirects:
-  Check `pretix.cfg` for `url=https://advantix.tech` and `trust_x_forwarded_proto=true`, then verify the origin sees `X-Forwarded-Proto: https`.
-- ACM shows pending validation:
-  The validation CNAMEs are missing or incorrect in Spaceship.
+  Spaceship apex/www records aren't pointing at the EC2 EIP.
+
+- `advantix.tech` resolves but HTTPS hangs / fails:
+  Caddy isn't running, or port 443 isn't open in the security
+  group, or first ACME issuance hasn't completed.
+  `docker compose logs caddy` is the first stop.
+
+- Caddy log shows `acme: invalid response` or `unauthorized`:
+  Port 80 isn't reachable from the public internet (Let's Encrypt
+  needs http-01 access). Check the security group.
+
+- HTTPS works but pretix emits `http://` redirects:
+  Check `pretix.cfg` for `url=https://advantix.tech` and
+  `trust_x_forwarded_proto=true`, then verify Caddy is sending
+  `X-Forwarded-Proto: https` upstream (it does by default per
+  the Caddyfile).
+
 - Root shows pretix's default install page:
-  CloudFront is bypassed or the root redirect function is not active.
+  `/ → /advantix/` redirect in `Caddyfile` isn't matching. Inspect
+  the Caddyfile and reload via `docker compose restart caddy`.
+
 - `www` does not redirect cleanly:
-  Re-publish `deployment/aws-demo/advantix-root-redirect.js`.
+  Check the `www.advantix.tech` site block in `Caddyfile`.
 
 ## Later Upgrades
 
-- restrict direct origin access with CloudFront-only origin hardening
-- move Postgres to `RDS`
-- move Redis to `ElastiCache`
-- split web and worker into `ECS`
-- move media to `S3` or `EFS`
+- harden direct origin access with a WAF (CloudFront, ALB+WAF, or
+  Cloudflare in front)
+- move Postgres to RDS
+- move Redis to ElastiCache
+- split web and worker into ECS
+- move media to S3 or EFS

--- a/deployment/aws-demo/docker-compose.yml
+++ b/deployment/aws-demo/docker-compose.yml
@@ -1,4 +1,21 @@
 services:
+  # Caddy terminates TLS on the host and reverse-proxies to the
+  # pretix container. Replaces the prior CloudFront fronting.
+  # See Caddyfile for the routing rules + ACME notes.
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      pretix:
+        condition: service_started
+
   db:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -37,8 +54,11 @@ services:
     environment:
       AUTOMIGRATE: "yes"
       NUM_WORKERS: "2"
-    ports:
-      - "80:80"
+    # Internal-only: Caddy reverse-proxies to pretix:80 over the
+    # docker network. No host port binding so Caddy can own 80/443
+    # on the EC2.
+    expose:
+      - "80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./pretix.cfg:/etc/pretix/pretix.cfg:ro
@@ -47,3 +67,9 @@ services:
 volumes:
   db-data:
   redis-data:
+  # Persists Caddy's ACME state (issued certs, account key, OCSP
+  # cache). Treat as durable — losing it triggers re-issuance and
+  # can hit Let's Encrypt rate limits (5 certs per exact-domain-set
+  # per week).
+  caddy-data:
+  caddy-config:

--- a/deployment/aws-demo/nginx.conf
+++ b/deployment/aws-demo/nginx.conf
@@ -17,7 +17,10 @@ http {
     tcp_nopush on;
     tcp_nodelay on;
 
-    # CloudFront sets X-Forwarded-Proto=https on the origin request.
+    # Caddy (the host-side TLS terminator on the same EC2) sets
+    # X-Forwarded-Proto=https on the upstream request. Pretix's
+    # Django app uses this (with trust_x_forwarded_proto=true in
+    # pretix.cfg) to emit https:// URLs in redirects.
     map $http_x_forwarded_proto $proxy_x_forwarded_proto {
         default $scheme;
         https https;


### PR DESCRIPTION
## Summary

Replace the CloudFront + ACM + viewer-function fronting layer on the **Advantix demo site only** with a Caddy 2 reverse proxy running on the same EC2 as pretix. **No changes to Resultant staging/prod or any non-Advantix surface.**

Why this simplification is right for the pilot:
- CloudFront's `/static/*` TTL (365d) + observed-broken CF→origin connectivity meant fresh deploys weren't reaching end users at the edge.
- For a single-server, single-customer demo, none of CF's features (edge cache, DDoS shield, geo distribution) earn their operational rent.
- Matches the devbox model: 1 server, 1 cert, no CDN.

### Architecture

**Before:** Spaceship → CloudFront (CNAME) → EC2:80 (pretix nginx). TLS at CF (ACM cert). 365d edge cache.

**After:** Spaceship → EC2 EIP (A) → Caddy on 80/443 → pretix:80 (via docker network). TLS at Caddy (Let's Encrypt, auto-renew). No edge cache.

### Files

- `deployment/aws-demo/Caddyfile` — **new**. Reverse proxy + auto-ACME + the two redirects formerly in `advantix-root-redirect.js` (www→apex 301, /→/advantix/ 302).
- `deployment/aws-demo/docker-compose.yml` — add \`caddy\` service binding host 80+443, persistent \`caddy-data\` and \`caddy-config\` volumes; remove the \`80:80\` host port binding on \`pretix\` and switch to \`expose: [80]\` (internal-only).
- `deployment/aws-demo/nginx.conf` — comment update only (Caddy now sets \`X-Forwarded-Proto\`, same behavior as CF did).
- `deployment/aws-demo/README.md` — rewrite of architecture/DNS/runtime sections; add \"Cutover from CloudFront\" runbook section.
- `deployment/aws-demo/PIPELINE.md` — mark the workflow's CloudFront invalidation step dormant (it's already graceful no-op when the variable is unset).

### Cutover plan (manual, after merge)

Detailed runbook lives in `README.md` → \"Cutover from CloudFront\".  Summary:

1. (A few hours before) Lower Spaceship DNS TTL on advantix.tech apex + www to 60s.
2. SSM into the EC2 (\`i-0e527b07a48513bb7\`, admin profile — devbox's \`staging-ops\` lacks SSM). Pull the new \`docker-compose.yml\`, \`Caddyfile\`, \`nginx.conf\` from \`mantric/pretix:master\` into \`/opt/advantix-pretix-demo/\`.
3. Switch Spaceship DNS: apex + www both \`A\` → EC2 EIP (\`44.203.226.36\`).
4. Wait for DNS propagation (~5 min with 60s TTL).
5. On the EC2: \`docker compose pull caddy && docker compose up -d --remove-orphans && docker compose logs -f caddy\`. Watch for \`certificate obtained successfully\`.
6. Smoke-test from a local terminal:
   - \`curl -sI https://advantix.tech/\` → 302 to /advantix/
   - \`curl -sI https://advantix.tech/advantix/\` → 200
   - \`curl -sI https://www.advantix.tech/\` → 301 to advantix.tech
7. Disable CloudFront distribution \`E386BQIE1YJIGW\` (set Enabled=false; delete after a day or two).
8. \`gh variable delete ADVANTIX_CF_DISTRIBUTION_ID --repo mantric/pretix\` to silence the workflow's dormant invalidation step.

**Expected downtime:** ~5-15 min, dominated by DNS propagation + first ACME issuance.

**Rollback:** revert DNS to the CloudFront CNAMEs and re-enable the CF distribution. pretix itself is unchanged.

### Out of scope (follow-up PR)

- Remove the CF invalidation step from \`.github/workflows/advantix-image-build.yml\`.
- Delete \`advantix-root-redirect.js\` (CF function source).
- Remove the CF-provisioning blocks from \`deploy-demo-ec2.sh\`.

Doing these in a separate PR keeps this one focused on the cutover and leaves a clean rollback path if anything in the Caddy stack surprises us during soak.

### Test plan

- [ ] PR CI green (Tests, Packaging, isort, flake8, licenseheaders, resultant/verification).
- [ ] After merge + cutover, \`https://advantix.tech/advantix/\` returns 200 with the new HTTPS cert (Let's Encrypt).
- [ ] \`https://www.advantix.tech/...\` 301s to the apex with URI preserved.
- [ ] \`curl -sI http://advantix.tech/\` 301s to HTTPS (Caddy default).
- [ ] CloudFront distribution \`E386BQIE1YJIGW\` set to \`Enabled=false\` and the site still works (proves CF is out of the path).
- [ ] A subsequent deploy (master push) lands on the live site within ~3 min of merge without any invalidation step needed.

### What this does NOT change

- ❌ Anything in \`appgraph\` (Resultant API, ECS, ACM for *.resultant.dev, RDS, OIDC roles, secrets)
- ❌ \`api.staging.resultant.dev\`, \`dev.kapil.resultant.dev\`, \`staging.resultant.dev\`
- ❌ The \`resultant-bot\` GitHub identity, PAT, or its OIDC role
- ❌ The pretix application code, plugins, theme, or pretix.cfg

🤖 Generated with [Claude Code](https://claude.com/claude-code)