### PR TITLE
chore: post-Caddy-cutover E2E smoke marker

### DIFF
--- a/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
+++ b/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
@@ -23,6 +23,24 @@
     display: none;
 }
 
+/*
+ * Post-Caddy-cutover smoke marker — Epic 6 closeout verification.
+ * Same intent as the Story 6.9 marker above, but this one specifically
+ * proves the chain works after the CloudFront -> Caddy cutover landed
+ * (mantric/pretix#46). Probe with:
+ *
+ *   curl -s https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css \
+ *     | grep advantix-caddy-cutover-2026-05-26
+ *
+ * The HTTPS path now flows through Caddy on the EC2 (no CloudFront in
+ * the chain), so no edge cache busting is needed; the marker should
+ * appear at the URL above within ~3-5 min of the master merge.
+ */
+.advantix-caddy-cutover-2026-05-26 {
+    /* Intentional no-op rule; never selected. Marker only. */
+    display: none;
+}
+
 body.advantix-theme {
     --advantix-midnight: #0A0E1A;
     --advantix-surface: #141828;


### PR DESCRIPTION
## Summary

Adds a tiny CSS marker (\`.advantix-caddy-cutover-2026-05-26\`) to \`advantix.css\` so a curl-grep can prove the post-cutover deploy chain (PR -> ECR -> EC2 poller -> docker compose -> Caddy -> HTTPS) is intact end-to-end.

Same shape as Story 6.9's marker; the difference is this one validates **Caddy** is in the path, not CloudFront.

## Why now

\`mantric/pretix#46\` (the CloudFront -> Caddy cutover) just merged + landed live. This PR is the E2E sanity check before we close out the Epic 6 documentation.

## Test plan

After merge:
- [ ] Watch \`Advantix image build\` workflow push a new \`latest\` to ECR.
- [ ] Within ~60-120s of ECR push, \`curl -s https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css | grep advantix-caddy-cutover-2026-05-26\` returns a match.
- [ ] No manual cache busting required (no CloudFront in path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)