### PR TITLE
chore: browser-visible E2E smoke marker (Epic 6 closeout)

### DIFF
--- a/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
+++ b/src/pretix/plugins/advantixtheme/static/pretixplugins/advantixtheme/advantix.css
@@ -24,6 +24,40 @@
 }
 
 /*
+ * Browser-visible E2E smoke marker — Epic 6 closeout.
+ *
+ * Renders a small Advantix-gold badge in the bottom-right corner of
+ * every advantix-themed page. Unlike the curl-grep markers above and
+ * below, this one is intentionally visible to a human looking at
+ * https://advantix.tech in a browser, to satisfy the "visual
+ * verification" leg of the Epic 6 end-to-end test.
+ *
+ * Stack proven by this badge appearing in the browser:
+ *   PR merge -> GitHub Actions image build -> ECR latest -> EC2
+ *   poller pull -> docker compose up -d pretix -> Caddy serves
+ *   the new /static/.../advantix.css with this rule -> the browser
+ *   re-fetches the CSS (no edge cache) -> badge renders.
+ *
+ * Remove this block as part of the Epic 6 closeout cleanup PR.
+ */
+body.advantix-theme::before {
+    content: "Resultant E2E · 2026-05-26";
+    position: fixed;
+    bottom: 8px;
+    right: 8px;
+    background: var(--advantix-gold-bright, #F5C842);
+    color: var(--advantix-midnight, #0A0E1A);
+    padding: 4px 10px;
+    font-size: 11px;
+    font-family: -apple-system, "Segoe UI", Roboto, sans-serif;
+    z-index: 9999;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(10, 14, 26, 0.18);
+    pointer-events: none;
+    letter-spacing: 0.4px;
+}
+
+/*
  * Post-Caddy-cutover smoke marker — Epic 6 closeout verification.
  * Same intent as the Story 6.9 marker above, but this one specifically
  * proves the chain works after the CloudFront -> Caddy cutover landed


### PR DESCRIPTION
## Summary

Visual-leg E2E smoke for the Epic 6 closeout. The file-level chain was already proven (file-level marker visible at the HTTPS URL via curl + grep) — this PR adds the **browser-visible** confirmation by rendering a small Advantix-gold badge in the bottom-right corner of every advantix-themed page.

When this lands you should see a small \`Resultant E2E · 2026-05-26\` badge fixed in the bottom-right when you open https://advantix.tech in a browser. No other UI changes.

## What it proves

That a merge on master shows up **rendered in a browser** at https://advantix.tech without any manual cache busting — the post-Caddy-cutover stack does not have an edge cache, so the next browser fetch of \`/static/.../advantix.css\` picks up the new rule and renders the badge.

## Test plan

- [ ] All 6 required CI checks pass on this PR.
- [ ] After merge, watch \`Advantix image build\` push a new \`latest\` to ECR.
- [ ] Within ~3-5 min of merge, open https://advantix.tech/advantix/ in a browser — the gold badge should be visible in the bottom-right corner.
- [ ] \`curl -s https://advantix.tech/static/pretixplugins/advantixtheme/advantix.css | grep "Resultant E2E"\` returns a match.

## Cleanup

The badge is intentionally removed as part of the Epic 6 closeout cleanup PR (alongside the file-level markers and the CloudFront-era artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)